### PR TITLE
qmake buildsystem fixes

### DIFF
--- a/common/common.pro
+++ b/common/common.pro
@@ -11,10 +11,10 @@ SOURCES = \
 HEADERS = fileprovider.h
 
 QT -= gui
-QT += xml
+QT += xml network
 
-INCLUDEPATH += $${TOP_SOURCE_DIR}/kdwsdl2cpp $${TOP_SOURCE_DIR}/kdwsdl2cpp/libxmlcommon
+INCLUDEPATH += $${PWD}/.. $${PWD}/../libkode
 
-include ($${TOP_SOURCE_DIR}/variables.pri)
+include ($${PWD}/variables.pri)
 DEFINES -= QT_NO_CAST_TO_ASCII QBA_NO_CAST_TO_VOID QBA_NO_CAST_TO_ASCII QT_NO_CAST_FROM_ASCII
 

--- a/libkode/kode_export.h
+++ b/libkode/kode_export.h
@@ -1,0 +1,5 @@
+/* We use static libs, no need for export macros */
+#define KODE_EXPORT
+#define KXMLCOMMON_EXPORT
+#define KWSDL_EXPORT
+#define SCHEMA_EXPORT

--- a/libkode/libkode.pro
+++ b/libkode/libkode.pro
@@ -17,8 +17,8 @@ SOURCES += \
 
 QT -= gui
 
-INCLUDEPATH += $${TOP_SOURCE_DIR}/kdwsdl2cpp
+INCLUDEPATH += $${PWD}
 
-include($${TOP_SOURCE_DIR}/variables.pri)
+include($${PWD}/variables.pri)
 DEFINES -= QT_NO_CAST_TO_ASCII QBA_NO_CAST_TO_VOID QBA_NO_CAST_TO_ASCII QT_NO_CAST_FROM_ASCII
 

--- a/schema/schema.pro
+++ b/schema/schema.pro
@@ -19,9 +19,9 @@ SOURCES = \
 QT -= gui
 QT += xml
 
-INCLUDEPATH += $${TOP_SOURCE_DIR}/kdwsdl2cpp
+INCLUDEPATH += $${PWD}/.. $${PWD}/../libkode
 
-include($${TOP_SOURCE_DIR}/variables.pri)
+include($${PWD}/variables.pri)
 DEFINES -= QT_NO_CAST_TO_ASCII QBA_NO_CAST_TO_VOID QBA_NO_CAST_TO_ASCII QT_NO_CAST_FROM_ASCII
 
 HEADERS += \

--- a/variables.pri
+++ b/variables.pri
@@ -1,0 +1,54 @@
+CONFIG += qt warn_on
+
+exists( g++.pri ):include( g++.pri )
+
+DEFINES += USE_EXCEPTIONS QT_FATAL_ASSERT
+
+DEFINES += QT_NO_CAST_TO_ASCII QT_NO_CAST_FROM_ASCII QT_NO_CAST_FROM_BYTEARRAY
+
+solaris-cc:DEFINES += SUN7
+
+# for C++11 support
+mac: QMAKE_CXXFLAGS += -stdlib=libc++
+
+win32-msvc*:DEFINES += _SCL_SECURE_NO_WARNINGS
+
+win32-msvc*:QMAKE_CXXFLAGS += /GR /EHsc /wd4251
+unix:!macx:QMAKE_LFLAGS += -Wl,-no-undefined
+macx:QMAKE_SONAME_PREFIX = @rpath
+
+CONFIG += depend_includepath
+
+QT += network
+
+contains(TEMPLATE, lib) {
+  DESTDIR = $${TOP_BUILD_DIR}/lib
+}
+
+contains(TEMPLATE, app) {
+  DESTDIR = $${TOP_BUILD_DIR}/bin
+}
+
+staticlib {
+} else {
+  contains(TEMPLATE, lib) {
+    win32 {
+      DLLDESTDIR = $${TOP_BUILD_DIR}/bin
+      CONFIG += dll
+#skip_target_version_ext was introduced in Qt5.3 so we can't use it for Qt4.8 builds
+#so fallback to setting the empty VERSION trick.
+      VERSION=
+#      CONFIG += skip_target_version_ext
+    }
+  }
+}
+
+unix:!symbian {
+  MOC_DIR = .moc
+  OBJECTS_DIR = .obj
+  UI_DIR = .ui
+} else {
+  MOC_DIR = _moc
+  OBJECTS_DIR = _obj
+  UI_DIR = _ui
+}


### PR DESCRIPTION
make it stand-alone and not dependent on kdsoap/kdwsdl2cpp
(almost. still need to remove the dependence on Settings)