### PR TITLE
common/common.pro - hack to compile against kdwsdl2cpp

### DIFF
--- a/common/common.pro
+++ b/common/common.pro
@@ -14,6 +14,8 @@ QT -= gui
 QT += xml network
 
 INCLUDEPATH += $${PWD}/.. $${PWD}/../libkode
+#TEMPORARY. Needed until common is no longer dependent on kdwsdl2cpp Settings class
+INCLUDEPATH += $${TOP_SOURCE_DIR}/kdwsdl2cpp
 
 include ($${PWD}/variables.pri)
 DEFINES -= QT_NO_CAST_TO_ASCII QBA_NO_CAST_TO_VOID QBA_NO_CAST_TO_ASCII QT_NO_CAST_FROM_ASCII


### PR DESCRIPTION
needed because common is dependent on the Settings class
from kdwsdl2cpp.