### PR TITLE
Fix #4: removing depencency to the KDSOAP's Settings class

### DIFF
--- a/common/fileprovider.h
+++ b/common/fileprovider.h
@@ -35,13 +35,15 @@ class KXMLCOMMON_EXPORT FileProvider : QObject
     Q_OBJECT
 
 public:
-    FileProvider();
+    FileProvider(bool useLocalFilesOnly = false, const QStringList &importPathList = QStringList());
 
     bool get(const QUrl &url, QString &target);
     void cleanUp();
 
 private:
     QString mFileName;
+    bool mUseLocalFilesOnly = false;
+    QStringList mImportPathList;
 };
 
 #endif

--- a/schema/parser.cpp
+++ b/schema/parser.cpp
@@ -63,13 +63,20 @@ public:
 
     QStringList mImportedSchemas;
     QStringList mIncludedSchemas;
+
+    bool mUseLocalFilesOnly = false;
+    QStringList mImportPathList;
 };
 
-Parser::Parser(ParserContext *context, const QString &nameSpace) : d(new Private)
+Parser::Parser(ParserContext *context, const QString &nameSpace,
+               bool useLocalFilesOnly, const QStringList &importPathList) :
+    d(new Private)
 {
     d->mNameSpace = nameSpace;
     d->mDefaultQualifiedElements = false;
     d->mDefaultQualifiedAttributes = false;
+    d->mUseLocalFilesOnly = useLocalFilesOnly;
+    d->mImportPathList = importPathList;
     init(context);
 }
 
@@ -1083,7 +1090,7 @@ void Parser::importSchema(ParserContext *context, const QString &location)
         return;
     }
 
-    FileProvider provider;
+    FileProvider provider(d->mUseLocalFilesOnly, d->mImportPathList);
     QString fileName;
     const QUrl schemaLocation = urlForLocation(context, location);
     qDebug("importing schema at %s", schemaLocation.toEncoded().constData());
@@ -1130,7 +1137,7 @@ void Parser::importSchema(ParserContext *context, const QString &location)
 //      target namespace is the same as the including schema's target namespace"
 void Parser::includeSchema(ParserContext *context, const QString &location)
 {
-    FileProvider provider;
+    FileProvider provider(d->mUseLocalFilesOnly, d->mImportPathList);
     QString fileName;
     const QUrl schemaLocation = urlForLocation(context, location);
     qDebug("including schema at %s", schemaLocation.toEncoded().constData());

--- a/schema/parser.h
+++ b/schema/parser.h
@@ -45,7 +45,8 @@ class SCHEMA_EXPORT Parser
 public:
     enum { UNBOUNDED = 100000 };
 
-    Parser(ParserContext *context, const QString &nameSpace = QString());
+    Parser(ParserContext *context, const QString &nameSpace = QString(),
+           bool useLocalFilesOnly = false, const QStringList &includePathList = QStringList());
     Parser(const Parser &other);
     ~Parser();
 


### PR DESCRIPTION
Fix #4: removing depencency to the KDSOAP's Settings class by passingthe settings data through parameters to the FileProvider. (And moving the loaded SSL configuration global.)