### PR TITLE
[code_generation]Add ability to add realitve includes to classes

### DIFF
--- a/code_generation/class.cpp
+++ b/code_generation/class.cpp
@@ -41,7 +41,7 @@ public:
     MemberVariable::List mMemberVariables;
     QStringList mIncludes;
     QStringList mForwardDeclarations;
-    QStringList mHeaderIncludes;
+    Include::List mHeaderIncludes;
     Class::List mBaseClasses;
     Typedef::List mTypedefs;
     Enum::List mEnums;
@@ -190,23 +190,23 @@ QStringList Class::forwardDeclarations() const
     return d->mForwardDeclarations;
 }
 
-void Class::addHeaderInclude(const QString &include)
+void Class::addHeaderInclude(const QString &include, Include::IncludeType type)
 {
-    if (include.isEmpty())
+    auto newInclude = Include(include, type);
+    if (include.isEmpty() || d->mHeaderIncludes.contains(newInclude))
         return;
 
-    if (!d->mHeaderIncludes.contains(include))
-        d->mHeaderIncludes.append(include);
+    d->mHeaderIncludes.append(newInclude);
 }
 
-void Class::addHeaderIncludes(const QStringList &includes)
+void Class::addHeaderIncludes(const QStringList &includes, Include::IncludeType type)
 {
     QStringList::ConstIterator it;
     for (it = includes.constBegin(); it != includes.constEnd(); ++it)
-        addHeaderInclude(*it);
+        addHeaderInclude(*it, type);
 }
 
-QStringList Class::headerIncludes() const
+Include::List Class::headerIncludes() const
 {
     return d->mHeaderIncludes;
 }

--- a/code_generation/class.h
+++ b/code_generation/class.h
@@ -25,6 +25,7 @@
 #include <QtCore/QStringList>
 
 #include "enum.h"
+#include "include.h"
 #include "function.h"
 #include "membervariable.h"
 #include "typedef.h"
@@ -197,17 +198,17 @@ public:
      *             will be printed as '#include "qfile.h"' in the
      *             implementation.
      */
-    void addHeaderInclude(const QString &file);
+    void addHeaderInclude(const QString &file, Include::IncludeType type = Include::Global);
 
     /**
      * Adds a list of header includes to the class object.
      */
-    void addHeaderIncludes(const QStringList &files);
+    void addHeaderIncludes(const QStringList &files, Include::IncludeType type = Include::Global);
 
     /**
      * Returns the list of header includes.
      */
-    QStringList headerIncludes() const;
+    Include::List headerIncludes() const;
 
     /**
      * Adds a @param function to the class object.

--- a/code_generation/code_generation.pro
+++ b/code_generation/code_generation.pro
@@ -8,6 +8,7 @@ SOURCES += \
    printer.cpp \
    license.cpp \
    file.cpp \
+   include.cpp \
    class.cpp \
    function.cpp \
    variable.cpp \

--- a/code_generation/include.cpp
+++ b/code_generation/include.cpp
@@ -1,0 +1,34 @@
+/*
+    This file is part of libkode.
+
+    Copyright (c) 2020 Miklos Marton <martonmiklosqdev@gmail.com>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Library General Public
+    License as published by the Free Software Foundation; either
+    version 2 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Library General Public License for more details.
+
+    You should have received a copy of the GNU Library General Public License
+    along with this library; see the file COPYING.LIB.  If not, write to
+    the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+    Boston, MA 02110-1301, USA.
+*/
+#include "include.h"
+
+using namespace KODE;
+
+Include::Include(const QString &fileName, Include::IncludeType type_)
+    : includeFileName(fileName), type(type_)
+{
+
+}
+
+bool Include::operator==(const Include &other) const
+{
+    return type == other.type && includeFileName == other.includeFileName;
+}

--- a/code_generation/include.h
+++ b/code_generation/include.h
@@ -1,0 +1,49 @@
+/*
+    This file is part of libkode.
+
+    Copyright (c) 2020 Miklos Marton <martonmiklosqdev@gmail.com>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Library General Public
+    License as published by the Free Software Foundation; either
+    version 2 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Library General Public License for more details.
+
+    You should have received a copy of the GNU Library General Public License
+    along with this library; see the file COPYING.LIB.  If not, write to
+    the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+    Boston, MA 02110-1301, USA.
+*/
+#ifndef INCLUDE_H
+#define INCLUDE_H
+
+#include <QList>
+#include <QString>
+
+#include <kode_export.h>
+
+namespace KODE {
+
+class KODE_EXPORT Include
+{
+public:
+    enum IncludeType {
+        Global,
+        Relative
+    };
+    Include() = default;
+    Include(const QString & fileName, IncludeType type_ = Global);
+    bool operator== (const Include &other) const;
+    QString includeFileName;
+    IncludeType type = Global;
+
+    typedef QVector<Include> List;
+};
+
+} // end namespace KODE
+
+#endif // INCLUDE_H


### PR DESCRIPTION
In a project using libkode I needed to add includes to my generated classes with relative paths (with `#include "foobar.h"` format).

This PR adds the ability to specify the include mode through the Class class. 

The include type is specified by an additional optional argument and by default it set to Global (what is the current upstream behaviour.)