### PR TITLE
Add Parser::setLocalSchemas() to provide local copies of common schemas

### DIFF
--- a/common/fileprovider.h
+++ b/common/fileprovider.h
@@ -22,7 +22,7 @@
 #ifndef FILEPROVIDER_H
 #define FILEPROVIDER_H
 
-#include <QObject>
+#include <QMap>
 
 #include <kode_export.h>
 
@@ -30,12 +30,12 @@ QT_BEGIN_NAMESPACE
 class QUrl;
 QT_END_NAMESPACE
 
-class KXMLCOMMON_EXPORT FileProvider : QObject
+class KXMLCOMMON_EXPORT FileProvider
 {
-    Q_OBJECT
-
 public:
-    FileProvider(bool useLocalFilesOnly = false, const QStringList &importPathList = QStringList());
+    FileProvider(bool useLocalFilesOnly = false, const QStringList &importPathList = QStringList(),
+                 const QMap<QUrl, QString> &localSchemas = {});
+    ~FileProvider();
 
     bool get(const QUrl &url, QString &target);
     void cleanUp();
@@ -43,7 +43,8 @@ public:
 private:
     QString mFileName;
     bool mUseLocalFilesOnly = false;
-    QStringList mImportPathList;
+    const QStringList mImportPathList;
+    const QMap<QUrl, QString> mLocalSchemas;
 };
 
 #endif

--- a/schema/parser.h
+++ b/schema/parser.h
@@ -53,6 +53,13 @@ public:
 
     Parser &operator=(const Parser &other);
 
+    /**
+     * Configures the parser to use some local files instead of downloading specific schemas.
+     * @param localSchemas a map where the key is the schema URI and the value is the local path
+     * The local path can start with :/ to use the Qt resource system.
+     */
+    void setLocalSchemas(const QMap<QUrl, QString>& localSchemas);
+
     Types types() const;
 
     Annotation::List annotations() const;


### PR DESCRIPTION
E.g. KDSoap's kdwsdl2cpp will provide copies of soap-encoding v1.1 and
v1.2, and soap-envelope. This will avoid having to download those from
the internet when they are used in an <import> clause, making it
possible to build unittests on CIs without internet access.

See https://github.com/KDAB/KDSoap/issues/203