### PR TITLE
CMake project and Github Actions CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,8 +14,16 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v1
+      - name: Cache Qt
+        id: cache-qt
+        uses: actions/cache@v1.2.0
+        with:
+          path: ../Qt
+          key: ${{ runner.os }}-QtCache
       - name: Install Qt
         uses: jurplel/install-qt-action@v2.6.2
+        with:
+          cached: ${{ steps.cache-qt.outputs.cache-hit }}
       - name: Build with CMake in ${{ matrix.config.os }} / ${{ matrix.config.cxx }}
         env:
           CXX: ${{ matrix.config.cxx }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,20 +6,26 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest, windows-latest]
-    runs-on: ${{ matrix.os }}
-
+        config:
+          - { os: macos-latest, cxx: "clang++" }
+          - { os: ubuntu-latest, cxx: "g++" }
+          - { os: windows-latest, cxx: "cl" }
+    runs-on: ${{ matrix.config.os }}
     steps:
       - name: Checkout
         uses: actions/checkout@v1
       - name: Install Qt
         uses: jurplel/install-qt-action@v2.6.2
-      - name: Build with CMake in ${{ matrix.os }}
+      - name: Build with CMake in ${{ matrix.config.os }} / ${{ matrix.config.cxx }}
+        env:
+          CXX: ${{ matrix.config.cxx }}
         run: |
-          mkdir cmake_build && cd cmake_build
-          cmake ..
-          make -j2
-      - name: Build with QMake in ${{ matrix.os }}
+          cmake -B cmake_build
+          cmake --build cmake_build -j2
+      - name: Build with QMake in ${{ matrix.config.os }} / ${{ matrix.config.cxx }}
+        if: matrix.config.os != 'windows-latest'
+        env:
+          CXX: ${{ matrix.config.cxx }}
         run: |
           qmake
           make -j2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,25 @@
+name: build
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Install Qt
+        uses: jurplel/install-qt-action@v2.6.2
+      - name: Build with CMake in ${{ matrix.os }}
+        run: |
+          mkdir cmake_build && cd cmake_build
+          cmake ..
+          make -j2
+      - name: Build with QMake in ${{ matrix.os }}
+        run: |
+          qmake
+          make -j2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,23 @@
+cmake_minimum_required(VERSION 3.11)
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+project(libknode)
+
+find_package(Qt5Core REQUIRED)
+find_package(Qt5Network REQUIRED)
+find_package(Qt5Xml REQUIRED)
+
+set(CMAKE_AUTOMOC ON)
+
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+
+include_directories(SYSTEM
+	${CMAKE_CURRENT_SOURCE_DIR}
+	${CMAKE_CURRENT_SOURCE_DIR}/code_generation
+)
+
+add_subdirectory(code_generation)
+add_subdirectory(common)
+add_subdirectory(schema)

--- a/code_generation/CMakeLists.txt
+++ b/code_generation/CMakeLists.txt
@@ -1,0 +1,46 @@
+set(CODE_GENERATION_SOURCES
+	class.cpp
+	code.cpp
+	enum.cpp
+	file.cpp
+	function.cpp
+	include.cpp
+	license.cpp
+	membervariable.cpp
+	namer.cpp
+	printer.cpp
+	statemachine.cpp
+	style.cpp
+	typedef.cpp
+	variable.cpp
+)
+
+set(CODE_GENERATION_HEADERS
+	class.h
+	code.h
+	enum.h
+	file.h
+	function.h
+	include.h
+	kode_export.h
+	license.h
+	membervariable.h
+	namer.h
+	printer.h
+	statemachine.h
+	style.h
+	typedef.h
+	variable.h
+)
+
+add_library(kode STATIC
+	${CODE_GENERATION_SOURCES} ${CODE_GENERATION_HEADERS}
+)
+
+target_link_libraries(kode
+	Qt5::Core
+)
+
+target_include_directories(kode PUBLIC
+	Qt5::Core
+)

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -1,0 +1,27 @@
+set(COMMON_SOURCES
+	fileprovider.cpp
+	messagehandler.cpp
+	nsmanager.cpp
+	parsercontext.cpp
+	qname.cpp
+)
+
+set(COMMON_HEADERS
+	fileprovider.h
+	messagehandler.h
+	nsmanager.h
+	parsercontext.h
+	qname.h
+)
+
+add_library(xmlcommon STATIC
+	${COMMON_SOURCES} ${COMMON_HEADERS}
+)
+
+target_link_libraries(xmlcommon
+	Qt5::Network Qt5::Xml
+)
+
+target_include_directories(xmlcommon PUBLIC
+	Qt5::Network Qt5::Xml
+)

--- a/schema/CMakeLists.txt
+++ b/schema/CMakeLists.txt
@@ -1,0 +1,42 @@
+set(SCHEMA_SOURCES
+	annotation.cpp
+	attribute.cpp
+	attributegroup.cpp
+	complextype.cpp
+	compositor.cpp
+	element.cpp
+	group.cpp
+	parser.cpp
+	#schematest.cpp
+	simpletype.cpp
+	types.cpp
+	xmlelement.cpp
+	xsdtype.cpp
+)
+
+set(SCHEMA_HEADERS
+	annotation.h
+	attribute.h
+	attributegroup.h
+	complextype.h
+	compositor.h
+	element.h
+	group.h
+	parser.h
+	simpletype.h
+	types.h
+	xmlelement.h
+	xsdtype.h
+)
+
+add_library(xmlschema STATIC
+	${SCHEMA_SOURCES} ${SCHEMA_HEADERS}
+)
+
+target_link_libraries(xmlschema
+	Qt5::Xml
+)
+
+target_include_directories(xmlschema PUBLIC
+	Qt5::Xml
+)


### PR DESCRIPTION
Added cmake project files (#3) and CI based on Github Actions (partially addressed for #1).

Currently Github Actions CI supports this matrix:

| Target | Linux / gcc | macOS / clang | Windows / vs2019 |
|----------|--------|-----------|-------------|
| cmake | yes | yes | yes |
| qmake | yes | yes | no  |