### PR TITLE
libkode changes necessary for kode/#29

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,4 +72,7 @@ CMakeLists.txt.user*
 mocs*
 kxml_compiler/kxml_compiler*
 
+# cmake generates Codeblocks project???
+*.cbp
+
 # test generated codes

--- a/code_generation/enum.cpp
+++ b/code_generation/enum.cpp
@@ -88,7 +88,18 @@ QString Enum::declaration() const
         }
     }
 
+    if (!d->mEnums.isEmpty())
+        retval += QStringLiteral(", ");
+    if (d->mCombinable)
+        retval += QString("Invalid = %1").arg(value);
+    else
+        retval += QStringLiteral("Invalid");
     retval += QLatin1String(" };");
 
     return retval;
+}
+
+QStringList Enum::enumValues() const
+{
+    return d->mEnums;
 }

--- a/code_generation/enum.h
+++ b/code_generation/enum.h
@@ -72,6 +72,11 @@ public:
      */
     QString declaration() const;
 
+    /**
+     * Returns the list of the enum values
+     */
+    QStringList enumValues() const;
+
 private:
     class Private;
     Private *d;


### PR DESCRIPTION
To fix kode/#29 two things needed on libkode side:
- Add accessor to the Enum's item names
- Adding an Invalid entry to each enum declaration