### PR TITLE
Initialize DocumentBaseUrl when loading from file

### DIFF
--- a/schema/parser.cpp
+++ b/schema/parser.cpp
@@ -1396,6 +1396,7 @@ bool Parser::parse(ParserContext *context, QXmlInputSource *source)
 
 bool Parser::parseFile(ParserContext *context, QFile &file)
 {
+    context->setDocumentBaseUrlFromFileUrl(QUrl::fromLocalFile(file.fileName()));
     QXmlInputSource source(&file);
     return parse(context, &source);
 }


### PR DESCRIPTION
This step required on loading included relative files in order to determine
base directory.

Updated unittest case will follow to kode.