### PR TITLE
Add ability to generate enums with Q_ENUM macros

### DIFF
--- a/code_generation/enum.h
+++ b/code_generation/enum.h
@@ -27,6 +27,8 @@
 
 namespace KODE {
 
+class Code;
+
 class KODE_EXPORT Enum
 {
 public:
@@ -71,6 +73,21 @@ public:
      * Returns the textual presentation of the enum.
      */
     QString declaration() const;
+
+    /**
+     * Prints the declaration of the enum to the code
+     */
+    void printDeclaration(Code &code) const;
+
+    /**
+     * @brief setIsQENUM
+     * This method can be used to mark enums to have a Q_ENUM(enumname) macro generated after the
+     * declaration. If you add an enum with isQENUM set to a class make sure that the isQGadget
+     * or the isQObject property of the class is set before code generation.
+     * (The latter got set automatically if a signal or slot declaration to the class.)
+     * @param qenum
+     */
+    void setIsQENUM(bool qenum = true);
 
 private:
     class Private;

--- a/code_generation/printer.cpp
+++ b/code_generation/printer.cpp
@@ -206,7 +206,7 @@ QString Printer::Private::classHeader(const Class &classObject, bool publicMembe
 
         Enum::List::ConstIterator it;
         for (it = enums.constBegin(); it != enums.constEnd(); ++it)
-            code += (*it).declaration();
+            (*it).printDeclaration(code);
 
         if (mLabelsDefineIndent)
             code.unindent();
@@ -738,8 +738,7 @@ void Printer::printHeader(const File &file)
     Enum::List enums = file.fileEnums();
     Enum::List::ConstIterator enumIt;
     for (enumIt = enums.constBegin(); enumIt != enums.constEnd(); ++enumIt) {
-        out += (*enumIt).declaration();
-        out.newLine();
+        (*enumIt).printDeclaration(out);
     }
 
     // Create forward declarations


### PR DESCRIPTION
The enum declarations are indented to newlines. 
The enum class now generates the declarations through a Code object (which ease the indentation handling).
The Enum::declaration does not used elsewhere so we might remove that. KDSoap and KODE does not use it directly only through the Printer, which got modified in this commit to use the new Code object based approach. 