### PR TITLE
Generate Q_GADGET macro if the Class::isQGadget is true

### DIFF
--- a/code_generation/printer.cpp
+++ b/code_generation/printer.cpp
@@ -158,7 +158,13 @@ QString Printer::Private::classHeader(const Class &classObject, bool publicMembe
     if (classObject.isQObject()) {
         code += "Q_OBJECT";
         code.newLine();
+    } else {
+        if (classObject.isQGadget()) {
+            code += "Q_GADGET";
+            code.newLine();
+        }
     }
+
     Q_FOREACH (const QString &declMacro, classObject.declarationMacros()) {
         code += declMacro;
         code.newLine();


### PR DESCRIPTION
Class::set/isQGadget have been there for a while, however the Printer class it got ignored.