### PR TITLE
Update the github build action Qt installing step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
           path: ../Qt
           key: ${{ runner.os }}-QtCache
       - name: Install Qt
-        uses: jurplel/install-qt-action@v2.6.2
+        uses: jurplel/install-qt-action@v2.12.1
         with:
           cached: ${{ steps.cache-qt.outputs.cache-hit }}
       - name: Build with CMake in ${{ matrix.config.os }} / ${{ matrix.config.cxx }}


### PR DESCRIPTION
The CI builds failed because the set-env was deprecated in the Github workflows.

See:
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
https://github.com/jurplel/install-qt-action/issues/64
I have upgraded the jurplel/install-qt-action to the latest version, where this issue is fixed.