### PR TITLE
Removed Enum::declaration method

### DIFF
--- a/code_generation/enum.cpp
+++ b/code_generation/enum.cpp
@@ -69,32 +69,6 @@ QString Enum::name() const
     return d->mName;
 }
 
-QString Enum::declaration() const
-{
-    QString retval(QLatin1String("enum ") + d->mName + QLatin1String(" {"));
-    uint value = 0;
-    QStringList::ConstIterator it;
-    for (it = d->mEnums.constBegin(); it != d->mEnums.constEnd(); ++it, ++value) {
-        if (d->mCombinable) {
-            if (it == d->mEnums.constBegin())
-                retval += QString::fromLatin1(" %1 = %2").arg(*it).arg(1 << value);
-            else
-                retval += QString::fromLatin1(", %1 = %2").arg(*it).arg(1 << value);
-        } else {
-            if (it == d->mEnums.constBegin())
-                retval += QLatin1Char(' ') + *it;
-            else
-                retval += QLatin1String(", ") + *it;
-        }
-    }
-
-    retval += QLatin1String(" };");
-    if (d->mIsQENUM)
-        retval += QStringLiteral("\nQ_ENUM(%1)").arg(d->mName);
-
-    return retval;
-}
-
 void Enum::printDeclaration(Code &code) const
 {
     code.addLine(QStringLiteral("enum %1 {").arg(d->mName));

--- a/code_generation/enum.h
+++ b/code_generation/enum.h
@@ -70,11 +70,6 @@ public:
     QString name() const;
 
     /**
-     * Returns the textual presentation of the enum.
-     */
-    QString declaration() const;
-
-    /**
      * Prints the declaration of the enum to the code
      */
     void printDeclaration(Code &code) const;


### PR DESCRIPTION
As @dfaure-kdab suggested in the #32 discussion removing the unused Enum::declaration function.