### PR TITLE
kdwsdl2cpp: Avoid potential type collisions in nested complexTypes

### DIFF
--- a/schema/attribute.cpp
+++ b/schema/attribute.cpp
@@ -154,6 +154,22 @@ void Attribute::List::dump()
     }
 }
 
+bool operator==(const Attribute& lhs, const Attribute& rhs)
+{
+    return (// XmlElement:
+            lhs.isNull() == rhs.isNull()
+            && lhs.name() == rhs.name()
+            && lhs.nameSpace() == rhs.nameSpace()
+            // Attribute:
+            && lhs.type() == rhs.type()
+            && lhs.defaultValue() == rhs.defaultValue()
+            && lhs.fixedValue() == rhs.fixedValue()
+            && lhs.isQualified() == rhs.isQualified()
+            && lhs.attributeUse() == rhs.attributeUse()
+            && lhs.reference() == rhs.reference());
+    //Note: Ignoring documentation()
+}
+
 } // namespace XSD
 
 QDebug operator<<(QDebug dbg, const XSD::Attribute &attr)

--- a/schema/attribute.cpp
+++ b/schema/attribute.cpp
@@ -156,17 +156,13 @@ void Attribute::List::dump()
 
 bool operator==(const Attribute& lhs, const Attribute& rhs)
 {
-    return (// XmlElement:
-            lhs.isNull() == rhs.isNull()
-            && lhs.name() == rhs.name()
-            && lhs.nameSpace() == rhs.nameSpace()
+    return ( // XmlElement:
+            lhs.isNull() == rhs.isNull() && lhs.name() == rhs.name()
+             && lhs.nameSpace() == rhs.nameSpace()
             // Attribute:
-            && lhs.type() == rhs.type()
-            && lhs.defaultValue() == rhs.defaultValue()
-            && lhs.fixedValue() == rhs.fixedValue()
-            && lhs.isQualified() == rhs.isQualified()
-            && lhs.attributeUse() == rhs.attributeUse()
-            && lhs.reference() == rhs.reference());
+            && lhs.type() == rhs.type() && lhs.defaultValue() == rhs.defaultValue()
+            && lhs.fixedValue() == rhs.fixedValue() && lhs.isQualified() == rhs.isQualified()
+            && lhs.attributeUse() == rhs.attributeUse() && lhs.reference() == rhs.reference());
     //Note: Ignoring documentation()
 }
 

--- a/schema/attribute.cpp
+++ b/schema/attribute.cpp
@@ -156,7 +156,8 @@ void Attribute::List::dump()
 
 bool Attribute::operator==(const Attribute &other) const
 {
-    return (XmlElement::operator==(other) && nameSpace() == other.nameSpace()
+    return (XmlElement::operator==(other)
+            && nameSpace() == other.nameSpace()
             // Attribute:
             && type() == other.type() && defaultValue() == other.defaultValue()
             && fixedValue() == other.fixedValue() && isQualified() == other.isQualified()

--- a/schema/attribute.cpp
+++ b/schema/attribute.cpp
@@ -156,13 +156,10 @@ void Attribute::List::dump()
 
 bool Attribute::operator==(const Attribute &other) const
 {
-    return (XmlElement::operator==(other)
-            && nameSpace() == other.nameSpace()
-            // Attribute:
-            && type() == other.type() && defaultValue() == other.defaultValue()
-            && fixedValue() == other.fixedValue() && isQualified() == other.isQualified()
-            && attributeUse() == other.attributeUse() && reference() == other.reference());
-    // Note: Ignoring documentation()
+    return (XmlElement::operator==(other) && type() == other.type()
+            && defaultValue() == other.defaultValue() && fixedValue() == other.fixedValue()
+            && isQualified() == other.isQualified() && attributeUse() == other.attributeUse()
+            && reference() == other.reference());
 }
 
 } // namespace XSD

--- a/schema/attribute.cpp
+++ b/schema/attribute.cpp
@@ -154,15 +154,13 @@ void Attribute::List::dump()
     }
 }
 
-bool operator==(const Attribute &lhs, const Attribute &rhs)
+bool Attribute::operator==(const Attribute &other) const
 {
-    return ( // XmlElement:
-            lhs.isNull() == rhs.isNull() && lhs.name() == rhs.name()
-            && lhs.nameSpace() == rhs.nameSpace()
+    return (XmlElement::operator==(other) && nameSpace() == other.nameSpace()
             // Attribute:
-            && lhs.type() == rhs.type() && lhs.defaultValue() == rhs.defaultValue()
-            && lhs.fixedValue() == rhs.fixedValue() && lhs.isQualified() == rhs.isQualified()
-            && lhs.attributeUse() == rhs.attributeUse() && lhs.reference() == rhs.reference());
+            && type() == other.type() && defaultValue() == other.defaultValue()
+            && fixedValue() == other.fixedValue() && isQualified() == other.isQualified()
+            && attributeUse() == other.attributeUse() && reference() == other.reference());
     // Note: Ignoring documentation()
 }
 

--- a/schema/attribute.cpp
+++ b/schema/attribute.cpp
@@ -154,16 +154,16 @@ void Attribute::List::dump()
     }
 }
 
-bool operator==(const Attribute& lhs, const Attribute& rhs)
+bool operator==(const Attribute &lhs, const Attribute &rhs)
 {
     return ( // XmlElement:
             lhs.isNull() == rhs.isNull() && lhs.name() == rhs.name()
-             && lhs.nameSpace() == rhs.nameSpace()
+            && lhs.nameSpace() == rhs.nameSpace()
             // Attribute:
             && lhs.type() == rhs.type() && lhs.defaultValue() == rhs.defaultValue()
             && lhs.fixedValue() == rhs.fixedValue() && lhs.isQualified() == rhs.isQualified()
             && lhs.attributeUse() == rhs.attributeUse() && lhs.reference() == rhs.reference());
-    //Note: Ignoring documentation()
+    // Note: Ignoring documentation()
 }
 
 } // namespace XSD

--- a/schema/attribute.h
+++ b/schema/attribute.h
@@ -79,6 +79,13 @@ private:
     class Private;
     Private *d;
 };
+
+bool operator==(const Attribute& lhs, const Attribute& rhs);
+inline bool operator!=(const Attribute& lhs, const Attribute& rhs)
+{
+    return !(lhs == rhs);
+}
+
 }
 
 SCHEMA_EXPORT QDebug operator<<(QDebug dbg, const XSD::Attribute &attr);

--- a/schema/attribute.h
+++ b/schema/attribute.h
@@ -75,16 +75,18 @@ public:
 
     bool isResolved() const;
 
+    bool operator==(const Attribute &other) const;
+    inline bool operator!=(const Attribute &other) const
+    {
+        return !(*this == other);
+    }
+
 private:
     class Private;
     Private *d;
 };
 
-bool operator==(const Attribute &lhs, const Attribute &rhs);
-inline bool operator!=(const Attribute &lhs, const Attribute &rhs)
-{
-    return !(lhs == rhs);
-}
+
 
 }
 

--- a/schema/attribute.h
+++ b/schema/attribute.h
@@ -80,8 +80,8 @@ private:
     Private *d;
 };
 
-bool operator==(const Attribute& lhs, const Attribute& rhs);
-inline bool operator!=(const Attribute& lhs, const Attribute& rhs)
+bool operator==(const Attribute &lhs, const Attribute &rhs);
+inline bool operator!=(const Attribute &lhs, const Attribute &rhs)
 {
     return !(lhs == rhs);
 }

--- a/schema/attribute.h
+++ b/schema/attribute.h
@@ -76,17 +76,12 @@ public:
     bool isResolved() const;
 
     bool operator==(const Attribute &other) const;
-    inline bool operator!=(const Attribute &other) const
-    {
-        return !(*this == other);
-    }
+    inline bool operator!=(const Attribute &other) const { return !(*this == other); }
 
 private:
     class Private;
     Private *d;
 };
-
-
 
 }
 

--- a/schema/attributegroup.cpp
+++ b/schema/attributegroup.cpp
@@ -72,15 +72,13 @@ Attribute::List AttributeGroup::attributes() const
     return d->mAttributes;
 }
 
-bool operator==(const AttributeGroup& lhs, const AttributeGroup& rhs)
+bool operator==(const AttributeGroup &lhs, const AttributeGroup &rhs)
 {
-    return (// XmlElement:
-            lhs.isNull() == rhs.isNull()
-            && lhs.name() == rhs.name()
+    return ( // XmlElement:
+            lhs.isNull() == rhs.isNull() && lhs.name() == rhs.name()
             && lhs.nameSpace() == rhs.nameSpace()
             // AttributeGroup:
-            && lhs.reference() == rhs.reference()
-            && lhs.attributes() == rhs.attributes());
+            && lhs.reference() == rhs.reference() && lhs.attributes() == rhs.attributes());
 }
 
 }

--- a/schema/attributegroup.cpp
+++ b/schema/attributegroup.cpp
@@ -74,10 +74,8 @@ Attribute::List AttributeGroup::attributes() const
 
 bool AttributeGroup::operator==(const AttributeGroup &other) const
 {
-    return (XmlElement::operator==(other)
-            && nameSpace() == other.nameSpace()
-            // AttributeGroup:
-            && reference() == other.reference() && attributes() == other.attributes());
+    return (XmlElement::operator==(other) && reference() == other.reference()
+            && attributes() == other.attributes());
 }
 
 }

--- a/schema/attributegroup.cpp
+++ b/schema/attributegroup.cpp
@@ -71,4 +71,16 @@ Attribute::List AttributeGroup::attributes() const
 {
     return d->mAttributes;
 }
+
+bool operator==(const AttributeGroup& lhs, const AttributeGroup& rhs)
+{
+    return (// XmlElement:
+            lhs.isNull() == rhs.isNull()
+            && lhs.name() == rhs.name()
+            && lhs.nameSpace() == rhs.nameSpace()
+            // AttributeGroup:
+            && lhs.reference() == rhs.reference()
+            && lhs.attributes() == rhs.attributes());
+}
+
 }

--- a/schema/attributegroup.cpp
+++ b/schema/attributegroup.cpp
@@ -72,13 +72,11 @@ Attribute::List AttributeGroup::attributes() const
     return d->mAttributes;
 }
 
-bool operator==(const AttributeGroup &lhs, const AttributeGroup &rhs)
+bool AttributeGroup::operator==(const AttributeGroup &other) const
 {
-    return ( // XmlElement:
-            lhs.isNull() == rhs.isNull() && lhs.name() == rhs.name()
-            && lhs.nameSpace() == rhs.nameSpace()
+    return (XmlElement::operator==(other) && nameSpace() == other.nameSpace()
             // AttributeGroup:
-            && lhs.reference() == rhs.reference() && lhs.attributes() == rhs.attributes());
+            && reference() == other.reference() && attributes() == other.attributes());
 }
 
 }

--- a/schema/attributegroup.cpp
+++ b/schema/attributegroup.cpp
@@ -74,7 +74,8 @@ Attribute::List AttributeGroup::attributes() const
 
 bool AttributeGroup::operator==(const AttributeGroup &other) const
 {
-    return (XmlElement::operator==(other) && nameSpace() == other.nameSpace()
+    return (XmlElement::operator==(other)
+            && nameSpace() == other.nameSpace()
             // AttributeGroup:
             && reference() == other.reference() && attributes() == other.attributes());
 }

--- a/schema/attributegroup.h
+++ b/schema/attributegroup.h
@@ -50,8 +50,8 @@ private:
     Private *d;
 };
 
-bool operator==(const AttributeGroup& lhs, const AttributeGroup& rhs);
-inline bool operator!=(const AttributeGroup& lhs, const AttributeGroup& rhs)
+bool operator==(const AttributeGroup &lhs, const AttributeGroup &rhs);
+inline bool operator!=(const AttributeGroup &lhs, const AttributeGroup &rhs)
 {
     return !(lhs == rhs);
 }

--- a/schema/attributegroup.h
+++ b/schema/attributegroup.h
@@ -49,6 +49,13 @@ private:
     class Private;
     Private *d;
 };
+
+bool operator==(const AttributeGroup& lhs, const AttributeGroup& rhs);
+inline bool operator!=(const AttributeGroup& lhs, const AttributeGroup& rhs)
+{
+    return !(lhs == rhs);
+}
+
 }
 
 #endif

--- a/schema/attributegroup.h
+++ b/schema/attributegroup.h
@@ -46,17 +46,12 @@ public:
     Attribute::List attributes() const;
 
     bool operator==(const AttributeGroup &other) const;
-    inline bool operator!=(const AttributeGroup &other) const
-    {
-        return !(*this == other);
-    }
+    inline bool operator!=(const AttributeGroup &other) const { return !(*this == other); }
 
 private:
     class Private;
     Private *d;
 };
-
-
 
 }
 

--- a/schema/attributegroup.h
+++ b/schema/attributegroup.h
@@ -45,16 +45,18 @@ public:
     void setAttributes(const Attribute::List &attributes);
     Attribute::List attributes() const;
 
+    bool operator==(const AttributeGroup &other) const;
+    inline bool operator!=(const AttributeGroup &other) const
+    {
+        return !(*this == other);
+    }
+
 private:
     class Private;
     Private *d;
 };
 
-bool operator==(const AttributeGroup &lhs, const AttributeGroup &rhs);
-inline bool operator!=(const AttributeGroup &lhs, const AttributeGroup &rhs)
-{
-    return !(lhs == rhs);
-}
+
 
 }
 

--- a/schema/complextype.cpp
+++ b/schema/complextype.cpp
@@ -235,7 +235,8 @@ bool ComplexType::isEmpty() const
 
 bool ComplexType::operator==(const ComplexType &other) const
 {
-    return (XSDType::operator==(other) && nameSpace() == other.nameSpace()
+    return (XSDType::operator==(other)
+            && nameSpace() == other.nameSpace()
             // ComplexType:
             && baseDerivation() == other.baseDerivation() && baseTypeName() == other.baseTypeName()
             && arrayType() == other.arrayType() && elements() == other.elements()

--- a/schema/complextype.cpp
+++ b/schema/complextype.cpp
@@ -255,21 +255,18 @@ ComplexTypeList::iterator ComplexTypeList::findComplexType(const QName &qualifie
     return end();
 }
 
-bool operator==(const ComplexType& lhs, const ComplexType& rhs)
+bool operator==(const ComplexType &lhs, const ComplexType &rhs)
 {
     return (// XmlElement:
-            lhs.isNull() == rhs.isNull()
-            && lhs.name() == rhs.name()
+            lhs.isNull() == rhs.isNull() && lhs.name() == rhs.name()
             && lhs.nameSpace() == rhs.nameSpace()
             // XsdType:
             && lhs.contentModel() == rhs.contentModel()
             && lhs.substitutionElementName() == rhs.substitutionElementName()
             // ComplexType:
             && lhs.baseDerivation() == rhs.baseDerivation()
-            && lhs.baseTypeName() == rhs.baseTypeName()
-            && lhs.arrayType() == rhs.arrayType()
-            && lhs.elements() == rhs.elements()
-            && lhs.attributes() == rhs.attributes()
+            && lhs.baseTypeName() == rhs.baseTypeName() && lhs.arrayType() == rhs.arrayType()
+            && lhs.elements() == rhs.elements() && lhs.attributes() == rhs.attributes()
             && lhs.attributeGroups() == rhs.attributeGroups());
     // Note: Ignoring XmlElement::annotations(),
     // ComplexType::documentation(), isAnonymous(), isConflicting(), derivedTypes()

--- a/schema/complextype.cpp
+++ b/schema/complextype.cpp
@@ -241,8 +241,7 @@ bool ComplexType::operator==(const ComplexType &other) const
             && baseDerivation() == other.baseDerivation() && baseTypeName() == other.baseTypeName()
             && arrayType() == other.arrayType() && elements() == other.elements()
             && attributes() == other.attributes() && attributeGroups() == other.attributeGroups());
-    // Note: Ignoring XmlElement::annotations(),
-    // ComplexType::documentation(), isAnonymous(), isConflicting(), derivedTypes()
+    // Note: Ignoring documentation(), isAnonymous(), isConflicting(), derivedTypes()
 }
 
 ComplexType ComplexTypeList::complexType(const QName &qualifiedName) const

--- a/schema/complextype.cpp
+++ b/schema/complextype.cpp
@@ -62,6 +62,7 @@ ComplexType::~ComplexType()
 
 ComplexType &ComplexType::operator=(const ComplexType &other)
 {
+    XSDType::operator=(other);
     if (this == &other) {
         return *this;
     }
@@ -252,6 +253,26 @@ ComplexTypeList::iterator ComplexTypeList::findComplexType(const QName &qualifie
             return it;
         }
     return end();
+}
+
+bool operator==(const ComplexType& lhs, const ComplexType& rhs)
+{
+    return (// XmlElement:
+            lhs.isNull() == rhs.isNull()
+            && lhs.name() == rhs.name()
+            && lhs.nameSpace() == rhs.nameSpace()
+            // XsdType:
+            && lhs.contentModel() == rhs.contentModel()
+            && lhs.substitutionElementName() == rhs.substitutionElementName()
+            // ComplexType:
+            && lhs.baseDerivation() == rhs.baseDerivation()
+            && lhs.baseTypeName() == rhs.baseTypeName()
+            && lhs.arrayType() == rhs.arrayType()
+            && lhs.elements() == rhs.elements()
+            && lhs.attributes() == rhs.attributes()
+            && lhs.attributeGroups() == rhs.attributeGroups());
+    // Note: Ignoring XmlElement::annotations(),
+    // ComplexType::documentation(), isAnonymous(), isConflicting(), derivedTypes()
 }
 
 } // namespace XSD

--- a/schema/complextype.cpp
+++ b/schema/complextype.cpp
@@ -257,7 +257,7 @@ ComplexTypeList::iterator ComplexTypeList::findComplexType(const QName &qualifie
 
 bool operator==(const ComplexType &lhs, const ComplexType &rhs)
 {
-    return (// XmlElement:
+    return ( // XmlElement:
             lhs.isNull() == rhs.isNull() && lhs.name() == rhs.name()
             && lhs.nameSpace() == rhs.nameSpace()
             // XsdType:

--- a/schema/complextype.cpp
+++ b/schema/complextype.cpp
@@ -62,11 +62,11 @@ ComplexType::~ComplexType()
 
 ComplexType &ComplexType::operator=(const ComplexType &other)
 {
-    XSDType::operator=(other);
     if (this == &other) {
         return *this;
     }
 
+    XSDType::operator=(other);
     *d = *other.d;
 
     return *this;
@@ -233,6 +233,17 @@ bool ComplexType::isEmpty() const
             && d->mElements.isEmpty() && d->mBaseTypeName.isEmpty() && d->mArrayType.isEmpty();
 }
 
+bool ComplexType::operator==(const ComplexType &other) const
+{
+    return (XSDType::operator==(other) && nameSpace() == other.nameSpace()
+            // ComplexType:
+            && baseDerivation() == other.baseDerivation() && baseTypeName() == other.baseTypeName()
+            && arrayType() == other.arrayType() && elements() == other.elements()
+            && attributes() == other.attributes() && attributeGroups() == other.attributeGroups());
+    // Note: Ignoring XmlElement::annotations(),
+    // ComplexType::documentation(), isAnonymous(), isConflicting(), derivedTypes()
+}
+
 ComplexType ComplexTypeList::complexType(const QName &qualifiedName) const
 {
     // qDebug() << "looking for" << typeName << "ns=" << typeName.nameSpace();
@@ -253,23 +264,6 @@ ComplexTypeList::iterator ComplexTypeList::findComplexType(const QName &qualifie
             return it;
         }
     return end();
-}
-
-bool operator==(const ComplexType &lhs, const ComplexType &rhs)
-{
-    return ( // XmlElement:
-            lhs.isNull() == rhs.isNull() && lhs.name() == rhs.name()
-            && lhs.nameSpace() == rhs.nameSpace()
-            // XsdType:
-            && lhs.contentModel() == rhs.contentModel()
-            && lhs.substitutionElementName() == rhs.substitutionElementName()
-            // ComplexType:
-            && lhs.baseDerivation() == rhs.baseDerivation()
-            && lhs.baseTypeName() == rhs.baseTypeName() && lhs.arrayType() == rhs.arrayType()
-            && lhs.elements() == rhs.elements() && lhs.attributes() == rhs.attributes()
-            && lhs.attributeGroups() == rhs.attributeGroups());
-    // Note: Ignoring XmlElement::annotations(),
-    // ComplexType::documentation(), isAnonymous(), isConflicting(), derivedTypes()
 }
 
 } // namespace XSD

--- a/schema/complextype.h
+++ b/schema/complextype.h
@@ -98,6 +98,12 @@ public:
 
     bool isEmpty() const;
 
+    bool operator==(const ComplexType &other) const;
+    inline bool operator!=(const ComplexType &other) const
+    {
+        return !(*this == other);
+    }
+
 private:
     class Private;
     Private *d;
@@ -115,12 +121,6 @@ public:
     // Mutable lookup (for making changes), returns end() if not found
     iterator findComplexType(const QName &qualifiedName);
 };
-
-bool operator==(const ComplexType &lhs, const ComplexType &rhs);
-inline bool operator!=(const ComplexType &lhs, const ComplexType &rhs)
-{
-    return !(lhs == rhs);
-}
 
 } // namespace XSD
 

--- a/schema/complextype.h
+++ b/schema/complextype.h
@@ -99,10 +99,7 @@ public:
     bool isEmpty() const;
 
     bool operator==(const ComplexType &other) const;
-    inline bool operator!=(const ComplexType &other) const
-    {
-        return !(*this == other);
-    }
+    inline bool operator!=(const ComplexType &other) const { return !(*this == other); }
 
 private:
     class Private;

--- a/schema/complextype.h
+++ b/schema/complextype.h
@@ -116,8 +116,8 @@ public:
     iterator findComplexType(const QName &qualifiedName);
 };
 
-bool operator==(const ComplexType& lhs, const ComplexType& rhs);
-inline bool operator!=(const ComplexType& lhs, const ComplexType& rhs)
+bool operator==(const ComplexType &lhs, const ComplexType &rhs);
+inline bool operator!=(const ComplexType &lhs, const ComplexType &rhs)
 {
     return !(lhs == rhs);
 }

--- a/schema/complextype.h
+++ b/schema/complextype.h
@@ -116,6 +116,12 @@ public:
     iterator findComplexType(const QName &qualifiedName);
 };
 
+bool operator==(const ComplexType& lhs, const ComplexType& rhs);
+inline bool operator!=(const ComplexType& lhs, const ComplexType& rhs)
+{
+    return !(lhs == rhs);
+}
+
 } // namespace XSD
 
 SCHEMA_EXPORT QDebug operator<<(QDebug dbg, const XSD::ComplexType &type);

--- a/schema/element.cpp
+++ b/schema/element.cpp
@@ -219,6 +219,19 @@ bool Element::hasSubstitutions() const
     return d->mHasSubstitutions;
 }
 
+bool Element::operator==(const Element &other) const
+{
+    return (XmlElement::operator==(other)
+            // Element:
+            && type() == other.type() && groupId() == other.groupId()
+            && minOccurs() == other.minOccurs() && maxOccurs() == other.maxOccurs()
+            && defaultValue() == other.defaultValue() && isQualified() == other.isQualified()
+            && nillable() == other.nillable() && occurrence() == other.occurrence()
+            && reference() == other.reference() && compositor().type() == other.compositor().type()
+            && hasSubstitutions() == other.hasSubstitutions());
+    // Note: Ignoring documentation
+}
+
 Element ElementList::element(const QName &qualifiedName) const
 {
     const_iterator it = constBegin();
@@ -246,37 +259,21 @@ void ElementList::dump()
     }
 }
 
-bool operator==(const Element &lhs, const Element &rhs)
+bool ElementList::operator==(const ElementList &other) const
 {
-    return ( // XmlElement:
-            lhs.isNull() == rhs.isNull() && lhs.name() == rhs.name()
-            && lhs.nameSpace() == rhs.nameSpace()
-            // Element:
-            && lhs.type() == rhs.type() && lhs.groupId() == rhs.groupId()
-            && lhs.minOccurs() == rhs.minOccurs() && lhs.maxOccurs() == rhs.maxOccurs()
-            && lhs.defaultValue() == rhs.defaultValue() && lhs.isQualified() == rhs.isQualified()
-            && lhs.nillable() == rhs.nillable() && lhs.occurrence() == rhs.occurrence()
-            && lhs.reference() == rhs.reference()
-            && lhs.compositor().type() == rhs.compositor().type()
-            && lhs.hasSubstitutions() == rhs.hasSubstitutions());
-    // Note: Ignoring documentation
-}
-
-bool operator==(const ElementList &lhs, const ElementList &rhs)
-{
-    if (lhs.count() != rhs.count())
+    if (count() != other.count())
         return false;
 
     // Ordered vs. unordered composition should be specified for a whole composition, but
     // as the Compositor::Type is determined during parsing (per element)
     // comparing per element should be semantically identic:
-    for (int i = 0; i < lhs.count(); i++) {
-        const Element &e = lhs.at(i);
+    for (int i = 0; i < count(); i++) {
+        const Element &e = at(i);
         // ordered
-        if (e.compositor().type() == Compositor::Sequence && rhs.at(i) != e)
+        if (e.compositor().type() == Compositor::Sequence && other.at(i) != e)
             return false;
         // unordered
-        else if (e.compositor().type() != Compositor::Sequence && !rhs.contains(e))
+        else if (e.compositor().type() != Compositor::Sequence && !other.contains(e))
             return false;
     }
     return true;

--- a/schema/element.cpp
+++ b/schema/element.cpp
@@ -246,6 +246,47 @@ void ElementList::dump()
     }
 }
 
+bool operator==(const Element& lhs, const Element& rhs)
+{
+    return (// XmlElement:
+            lhs.isNull() == rhs.isNull()
+            && lhs.name() == rhs.name()
+            && lhs.nameSpace() == rhs.nameSpace()
+            // Element:
+            && lhs.type() == rhs.type()
+            && lhs.groupId() == rhs.groupId()
+            && lhs.minOccurs() == rhs.minOccurs()
+            && lhs.maxOccurs() == rhs.maxOccurs()
+            && lhs.defaultValue() == rhs.defaultValue()
+            && lhs.isQualified() == rhs.isQualified()
+            && lhs.nillable() == rhs.nillable()
+            && lhs.occurrence() == rhs.occurrence()
+            && lhs.reference() == rhs.reference()
+            && lhs.compositor().type() == rhs.compositor().type()
+            && lhs.hasSubstitutions() == rhs.hasSubstitutions());
+    //Note: Ignoring documentation
+}
+
+bool operator==(const ElementList& lhs, const ElementList& rhs)
+{
+    if (lhs.count() != rhs.count())
+        return false;
+
+    // Ordered vs. unordered composition should be specified for a whole composition, but
+    // as the Compositor::Type is determined during parsing (per element)
+    // comparing per element should be semantically identic:
+    for (int i = 0; i < lhs.count(); i++) {
+        const Element& e = lhs.at(i);
+        if (e.compositor().type() == Compositor::Sequence  // ordered
+                && rhs.at(i) != e)
+            return false;
+        else if (e.compositor().type() != Compositor::Sequence  // unordered
+                 && !rhs.contains(e))
+            return false;
+    }
+    return true;
+}
+
 } // namespace XSD
 
 QDebug operator<<(QDebug dbg, const XSD::Element &element)

--- a/schema/element.cpp
+++ b/schema/element.cpp
@@ -246,28 +246,23 @@ void ElementList::dump()
     }
 }
 
-bool operator==(const Element& lhs, const Element& rhs)
+bool operator==(const Element &lhs, const Element &rhs)
 {
-    return (// XmlElement:
-            lhs.isNull() == rhs.isNull()
-            && lhs.name() == rhs.name()
+    return ( // XmlElement:
+            lhs.isNull() == rhs.isNull() && lhs.name() == rhs.name()
             && lhs.nameSpace() == rhs.nameSpace()
             // Element:
-            && lhs.type() == rhs.type()
-            && lhs.groupId() == rhs.groupId()
-            && lhs.minOccurs() == rhs.minOccurs()
-            && lhs.maxOccurs() == rhs.maxOccurs()
-            && lhs.defaultValue() == rhs.defaultValue()
-            && lhs.isQualified() == rhs.isQualified()
-            && lhs.nillable() == rhs.nillable()
-            && lhs.occurrence() == rhs.occurrence()
+            && lhs.type() == rhs.type() && lhs.groupId() == rhs.groupId()
+            && lhs.minOccurs() == rhs.minOccurs() && lhs.maxOccurs() == rhs.maxOccurs()
+            && lhs.defaultValue() == rhs.defaultValue() && lhs.isQualified() == rhs.isQualified()
+            && lhs.nillable() == rhs.nillable() && lhs.occurrence() == rhs.occurrence()
             && lhs.reference() == rhs.reference()
             && lhs.compositor().type() == rhs.compositor().type()
             && lhs.hasSubstitutions() == rhs.hasSubstitutions());
     //Note: Ignoring documentation
 }
 
-bool operator==(const ElementList& lhs, const ElementList& rhs)
+bool operator==(const ElementList &lhs, const ElementList &rhs)
 {
     if (lhs.count() != rhs.count())
         return false;
@@ -276,12 +271,12 @@ bool operator==(const ElementList& lhs, const ElementList& rhs)
     // as the Compositor::Type is determined during parsing (per element)
     // comparing per element should be semantically identic:
     for (int i = 0; i < lhs.count(); i++) {
-        const Element& e = lhs.at(i);
-        if (e.compositor().type() == Compositor::Sequence  // ordered
-                && rhs.at(i) != e)
+        const Element &e = lhs.at(i);
+        // ordered
+        if (e.compositor().type() == Compositor::Sequence && rhs.at(i) != e)
             return false;
-        else if (e.compositor().type() != Compositor::Sequence  // unordered
-                 && !rhs.contains(e))
+        // unordered
+        else if (e.compositor().type() != Compositor::Sequence && !rhs.contains(e))
             return false;
     }
     return true;

--- a/schema/element.cpp
+++ b/schema/element.cpp
@@ -259,7 +259,7 @@ bool operator==(const Element &lhs, const Element &rhs)
             && lhs.reference() == rhs.reference()
             && lhs.compositor().type() == rhs.compositor().type()
             && lhs.hasSubstitutions() == rhs.hasSubstitutions());
-    //Note: Ignoring documentation
+    // Note: Ignoring documentation
 }
 
 bool operator==(const ElementList &lhs, const ElementList &rhs)

--- a/schema/element.h
+++ b/schema/element.h
@@ -116,14 +116,14 @@ public:
     void dump();
 };
 
-bool operator==(const Element& lhs, const Element& rhs);
-inline bool operator!=(const Element& lhs, const Element& rhs)
+bool operator==(const Element &lhs, const Element &rhs);
+inline bool operator!=(const Element &lhs, const Element &rhs)
 {
     return !(lhs == rhs);
 }
 
-bool operator==(const ElementList& lhs, const ElementList& rhs);
-inline bool operator!=(const ElementList& lhs, const ElementList& rhs)
+bool operator==(const ElementList &lhs, const ElementList &rhs);
+inline bool operator!=(const ElementList &lhs, const ElementList &rhs)
 {
     return !(lhs == rhs);
 }

--- a/schema/element.h
+++ b/schema/element.h
@@ -115,6 +115,19 @@ public:
     // For debugging
     void dump();
 };
+
+bool operator==(const Element& lhs, const Element& rhs);
+inline bool operator!=(const Element& lhs, const Element& rhs)
+{
+    return !(lhs == rhs);
+}
+
+bool operator==(const ElementList& lhs, const ElementList& rhs);
+inline bool operator!=(const ElementList& lhs, const ElementList& rhs)
+{
+    return !(lhs == rhs);
+}
+
 }
 
 SCHEMA_EXPORT QDebug operator<<(QDebug dbg, const XSD::Element &element);

--- a/schema/element.h
+++ b/schema/element.h
@@ -98,6 +98,12 @@ public:
      */
     bool hasSubstitutions() const;
 
+    bool operator==(const Element &other) const;
+    inline bool operator!=(const Element &other) const
+    {
+        return !(*this == other);
+    }
+
 private:
     class Private;
     Private *d;
@@ -114,19 +120,13 @@ public:
 
     // For debugging
     void dump();
+
+    bool operator==(const ElementList &other) const;
+    inline bool operator!=(const ElementList &other) const
+    {
+        return !(*this == other);
+    }
 };
-
-bool operator==(const Element &lhs, const Element &rhs);
-inline bool operator!=(const Element &lhs, const Element &rhs)
-{
-    return !(lhs == rhs);
-}
-
-bool operator==(const ElementList &lhs, const ElementList &rhs);
-inline bool operator!=(const ElementList &lhs, const ElementList &rhs)
-{
-    return !(lhs == rhs);
-}
 
 }
 

--- a/schema/element.h
+++ b/schema/element.h
@@ -99,10 +99,7 @@ public:
     bool hasSubstitutions() const;
 
     bool operator==(const Element &other) const;
-    inline bool operator!=(const Element &other) const
-    {
-        return !(*this == other);
-    }
+    inline bool operator!=(const Element &other) const { return !(*this == other); }
 
 private:
     class Private;
@@ -122,10 +119,7 @@ public:
     void dump();
 
     bool operator==(const ElementList &other) const;
-    inline bool operator!=(const ElementList &other) const
-    {
-        return !(*this == other);
-    }
+    inline bool operator!=(const ElementList &other) const { return !(*this == other); }
 };
 
 }

--- a/schema/group.cpp
+++ b/schema/group.cpp
@@ -77,10 +77,9 @@ bool Group::isResolved() const
     return !d->mElements.isEmpty() || d->mReference.isEmpty();
 }
 
-bool operator==(const Group& lhs, const Group& rhs)
+bool operator==(const Group &lhs, const Group &rhs)
 {
-    return (lhs.reference() == rhs.reference()
-            && lhs.elements() == rhs.elements());  // FIXME:
+    return (lhs.reference() == rhs.reference() && lhs.elements() == rhs.elements());
 }
 
 }

--- a/schema/group.cpp
+++ b/schema/group.cpp
@@ -76,6 +76,13 @@ bool Group::isResolved() const
 {
     return !d->mElements.isEmpty() || d->mReference.isEmpty();
 }
+
+bool operator==(const Group& lhs, const Group& rhs)
+{
+    return (lhs.reference() == rhs.reference()
+            && lhs.elements() == rhs.elements());  // FIXME:
+}
+
 }
 
 QDebug operator<<(QDebug dbg, const XSD::Group &group)

--- a/schema/group.cpp
+++ b/schema/group.cpp
@@ -77,9 +77,10 @@ bool Group::isResolved() const
     return !d->mElements.isEmpty() || d->mReference.isEmpty();
 }
 
-bool operator==(const Group &lhs, const Group &rhs)
+bool Group::operator==(const Group &other) const
 {
-    return (lhs.reference() == rhs.reference() && lhs.elements() == rhs.elements());
+    return (XmlElement::operator==(other) && reference() == other.reference()
+            && elements() == other.elements());
 }
 
 }

--- a/schema/group.h
+++ b/schema/group.h
@@ -31,6 +31,7 @@ public:
 
     bool operator==(const Group &other) const;
     inline bool operator!=(const Group &other) const { return !(*this == other); }
+
 private:
     class Private;
     Private *d;

--- a/schema/group.h
+++ b/schema/group.h
@@ -34,8 +34,8 @@ private:
     Private *d;
 };
 
-bool operator==(const Group& lhs, const Group& rhs);
-inline bool operator!=(const Group& lhs, const Group& rhs)
+bool operator==(const Group &lhs, const Group &rhs);
+inline bool operator!=(const Group &lhs, const Group &rhs)
 {
     return !(lhs == rhs);
 }

--- a/schema/group.h
+++ b/schema/group.h
@@ -33,6 +33,13 @@ private:
     class Private;
     Private *d;
 };
+
+bool operator==(const Group& lhs, const Group& rhs);
+inline bool operator!=(const Group& lhs, const Group& rhs)
+{
+    return !(lhs == rhs);
+}
+
 }
 
 SCHEMA_EXPORT QDebug operator<<(QDebug dbg, const XSD::Group &group);

--- a/schema/group.h
+++ b/schema/group.h
@@ -30,16 +30,11 @@ public:
     bool isResolved() const;
 
     bool operator==(const Group &other) const;
-    inline bool operator!=(const Group &other) const
-    {
-        return !(*this == other);
-    }
+    inline bool operator!=(const Group &other) const { return !(*this == other); }
 private:
     class Private;
     Private *d;
 };
-
-
 
 }
 

--- a/schema/group.h
+++ b/schema/group.h
@@ -29,16 +29,17 @@ public:
 
     bool isResolved() const;
 
+    bool operator==(const Group &other) const;
+    inline bool operator!=(const Group &other) const
+    {
+        return !(*this == other);
+    }
 private:
     class Private;
     Private *d;
 };
 
-bool operator==(const Group &lhs, const Group &rhs);
-inline bool operator!=(const Group &lhs, const Group &rhs)
-{
-    return !(lhs == rhs);
-}
+
 
 }
 

--- a/schema/parser.cpp
+++ b/schema/parser.cpp
@@ -39,7 +39,7 @@ static const QString WSDLSchemaURI(QLatin1String("http://schemas.xmlsoap.org/wsd
 static const QString soapEncNs = QLatin1String("http://schemas.xmlsoap.org/soap/encoding/");
 static const QString soap12EncNs = QLatin1String("http://www.w3.org/2003/05/soap-encoding");
 
-Q_LOGGING_CATEGORY(parser, "libkode.parser")
+Q_LOGGING_CATEGORY(parser, "libkode.parser", QtWarningMsg)
 
 namespace XSD {
 

--- a/schema/parser.cpp
+++ b/schema/parser.cpp
@@ -514,13 +514,27 @@ Element Parser::parseElement(ParserContext *context, const QDomElement &element,
             // qDebug() << "childName:" << childName.localName();
             if (childName.localName() == QLatin1String("complexType")) {
                 ComplexType ct = parseComplexType(context, childElement);
-
-                ct.setName(newElement.name());
                 ct.setAnonymous(true);
-                d->mComplexTypes.append(ct);
-                qCDebug(parser)
-                        << " found nested complexType element, type name is now element name, i.e. "
-                        << ct.name() << "newElement.setType" << ct.qualifiedName();
+                ct.setName(newElement.name());
+                int i = 0;
+                bool typeExists = false;
+                ComplexType existingType = d->mComplexTypes.complexType(QName(ct.nameSpace(), ct.name()));
+                while (existingType != ComplexType()) {
+                    if (existingType == ct) {
+                        qCDebug(parser) << "  Nested complexType of name" << ct.name() << "is structurally identical with existing complexType of the same name, skipping this instance...";
+                        typeExists = true;
+                        break;
+                    } else {
+                        ct.setName(newElement.name() + QString::number(++i));
+                        existingType = d->mComplexTypes.complexType(QName(ct.nameSpace(), ct.name()));
+                    }
+                }
+                if (!typeExists) {
+                    d->mComplexTypes.append(ct);
+                    if (newElement.name() != ct.name())
+                        qCDebug(parser) << "  Detected type collision for nested complexType, updated name" << newElement.name() << "to" << ct.name();
+                    qCDebug(parser) << " found nested complexType element, type name is now element name, i.e. " << ct.name() << "newElement.setType" << ct.qualifiedName();
+                }
                 newElement.setType(ct.qualifiedName());
             } else if (childName.localName() == QLatin1String("simpleType")) {
                 SimpleType st = parseSimpleType(context, childElement);

--- a/schema/parser.cpp
+++ b/schema/parser.cpp
@@ -520,7 +520,7 @@ Element Parser::parseElement(ParserContext *context, const QDomElement &element,
                 bool typeExists = false;
                 ComplexType existingType =
                         d->mComplexTypes.complexType(QName(ct.nameSpace(), ct.name()));
-                while (existingType != ComplexType()) {
+                while (!existingType.isNull()) {
                     if (existingType == ct) {
                         qCDebug(parser) << "  Nested complexType of name" << ct.name()
                                         << "is structurally identical with existing complexType of "

--- a/schema/parser.cpp
+++ b/schema/parser.cpp
@@ -518,22 +518,30 @@ Element Parser::parseElement(ParserContext *context, const QDomElement &element,
                 ct.setName(newElement.name());
                 int i = 0;
                 bool typeExists = false;
-                ComplexType existingType = d->mComplexTypes.complexType(QName(ct.nameSpace(), ct.name()));
+                ComplexType existingType =
+                        d->mComplexTypes.complexType(QName(ct.nameSpace(), ct.name()));
                 while (existingType != ComplexType()) {
                     if (existingType == ct) {
-                        qCDebug(parser) << "  Nested complexType of name" << ct.name() << "is structurally identical with existing complexType of the same name, skipping this instance...";
+                        qCDebug(parser) << "  Nested complexType of name" << ct.name()
+                                        << "is structurally identical with existing complexType of "
+                                           "the same name, skipping this instance...";
                         typeExists = true;
                         break;
                     } else {
                         ct.setName(newElement.name() + QString::number(++i));
-                        existingType = d->mComplexTypes.complexType(QName(ct.nameSpace(), ct.name()));
+                        existingType =
+                                d->mComplexTypes.complexType(QName(ct.nameSpace(), ct.name()));
                     }
                 }
                 if (!typeExists) {
                     d->mComplexTypes.append(ct);
                     if (newElement.name() != ct.name())
-                        qCDebug(parser) << "  Detected type collision for nested complexType, updated name" << newElement.name() << "to" << ct.name();
-                    qCDebug(parser) << " found nested complexType element, type name is now element name, i.e. " << ct.name() << "newElement.setType" << ct.qualifiedName();
+                        qCDebug(parser)
+                                << "  Detected type collision for nested complexType, updated name"
+                                << newElement.name() << "to" << ct.name();
+                    qCDebug(parser) << " found nested complexType element, type name is now "
+                                    << "element name, i.e. "
+                                    << ct.name() << "newElement.setType" << ct.qualifiedName();
                 }
                 newElement.setType(ct.qualifiedName());
             } else if (childName.localName() == QLatin1String("simpleType")) {

--- a/schema/parser.cpp
+++ b/schema/parser.cpp
@@ -540,8 +540,8 @@ Element Parser::parseElement(ParserContext *context, const QDomElement &element,
                                 << "  Detected type collision for nested complexType, updated name"
                                 << newElement.name() << "to" << ct.name();
                     qCDebug(parser) << " found nested complexType element, type name is now "
-                                    << "element name, i.e. "
-                                    << ct.name() << "newElement.setType" << ct.qualifiedName();
+                                    << "element name, i.e. " << ct.name() << "newElement.setType"
+                                    << ct.qualifiedName();
                 }
                 newElement.setType(ct.qualifiedName());
             } else if (childName.localName() == QLatin1String("simpleType")) {

--- a/schema/xmlelement.cpp
+++ b/schema/xmlelement.cpp
@@ -107,7 +107,8 @@ Annotation::List XmlElement::annotations() const
 
 bool XmlElement::operator==(const XmlElement &other) const
 {
-    return (isNull() == other.isNull() && name() == other.name());
+    return name() == other.name();
+    // Note: Ignoring annotations()
 }
 
 }

--- a/schema/xmlelement.cpp
+++ b/schema/xmlelement.cpp
@@ -104,4 +104,10 @@ Annotation::List XmlElement::annotations() const
 {
     return d->mAnnotations;
 }
+
+bool XmlElement::operator==(const XmlElement &other) const
+{
+    return (isNull() == other.isNull() && name() == other.name());
+}
+
 }

--- a/schema/xmlelement.h
+++ b/schema/xmlelement.h
@@ -55,10 +55,19 @@ public:
     void setAnnotations(const Annotation::List &);
     Annotation::List annotations() const;
 
+    bool operator==(const XmlElement &other) const;
+    inline bool operator!=(const XmlElement &other) const
+    {
+        return !(*this == other);
+    }
+
 private:
     class Private;
     Private *d;
 };
+
+
+
 }
 
 #endif

--- a/schema/xmlelement.h
+++ b/schema/xmlelement.h
@@ -56,17 +56,12 @@ public:
     Annotation::List annotations() const;
 
     bool operator==(const XmlElement &other) const;
-    inline bool operator!=(const XmlElement &other) const
-    {
-        return !(*this == other);
-    }
+    inline bool operator!=(const XmlElement &other) const { return !(*this == other); }
 
 private:
     class Private;
     Private *d;
 };
-
-
 
 }
 

--- a/schema/xsdtype.cpp
+++ b/schema/xsdtype.cpp
@@ -49,11 +49,11 @@ XSDType::~XSDType()
 
 XSDType &XSDType::operator=(const XSDType &other)
 {
-    XmlElement::operator=(other);
     if (this == &other) {
         return *this;
     }
 
+    XmlElement::operator=(other);
     *d = *other.d;
 
     return *this;
@@ -77,6 +77,12 @@ void XSDType::setSubstitutionElementName(const QName &name)
 QName XSDType::substitutionElementName() const
 {
     return d->mSubstitutionElementName;
+}
+
+bool XSDType::operator==(const XSDType &other) const
+{
+    return (XmlElement::operator==(other) && contentModel() == other.contentModel()
+            && substitutionElementName() == other.substitutionElementName());
 }
 
 } // namespace XSD

--- a/schema/xsdtype.cpp
+++ b/schema/xsdtype.cpp
@@ -49,6 +49,7 @@ XSDType::~XSDType()
 
 XSDType &XSDType::operator=(const XSDType &other)
 {
+    XmlElement::operator=(other);
     if (this == &other) {
         return *this;
     }

--- a/schema/xsdtype.h
+++ b/schema/xsdtype.h
@@ -101,6 +101,12 @@ public:
 
     virtual bool isSimple() const { return true; }
 
+    bool operator==(const XSDType &other) const;
+    inline bool operator!=(const XSDType &other) const
+    {
+        return !(*this == other);
+    }
+
 private:
     class Private;
     Private *d;

--- a/schema/xsdtype.h
+++ b/schema/xsdtype.h
@@ -102,10 +102,7 @@ public:
     virtual bool isSimple() const { return true; }
 
     bool operator==(const XSDType &other) const;
-    inline bool operator!=(const XSDType &other) const
-    {
-        return !(*this == other);
-    }
+    inline bool operator!=(const XSDType &other) const { return !(*this == other); }
 
 private:
     class Private;


### PR DESCRIPTION
Manual merge of pull request from Holger Kaelberer in KDSoap since
the code moved to this repository.

So far, for complexTypes nested in elements with the same name a
single C++ class has been created. This is wrong in cases where
multiple elements with the same name contain complexTypes of different
structure because different classes should be created

Beside, new types for structurally different complexTypes only.