### PR TITLE
Implement move support in XmlElement, based on a swap method.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 project(libkode)
 
 # Qt 5.9 required for QNetworkRequest::NoLessSafeRedirectPolicy
-find_package(Qt5 5.9.0 CONFIG REQUIRED COMPONENTS Core Network Xml)
+find_package(Qt5 5.9.0 CONFIG REQUIRED COMPONENTS Core Network Xml Test)
 
 set(CMAKE_AUTOMOC ON)
 
@@ -17,6 +17,9 @@ include_directories(SYSTEM
 	${CMAKE_CURRENT_SOURCE_DIR}/code_generation
 )
 
+enable_testing()
+
 add_subdirectory(code_generation)
 add_subdirectory(common)
 add_subdirectory(schema)
+add_subdirectory(autotests)

--- a/autotests/CMakeLists.txt
+++ b/autotests/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_executable(tst_xmlelement tst_xmlelement.cpp)
+target_link_libraries(tst_xmlelement xmlschema Qt5::Test)
+add_test(tst_xmlelement tst_xmlelement)

--- a/autotests/tst_xmlelement.cpp
+++ b/autotests/tst_xmlelement.cpp
@@ -1,0 +1,38 @@
+#include "xmlelement.h"
+
+#include <QTest>
+
+using namespace XSD;
+
+class XmlElementTest : public QObject
+{
+    Q_OBJECT
+private Q_SLOTS:
+    void constructors();
+    void assignment();
+};
+
+void XmlElementTest::constructors()
+{
+    XmlElement e("ns1");
+    e.setName("elem");
+    XmlElement copy(e);
+    QCOMPARE(copy.name(), "elem");
+    XmlElement moved = std::move(e);
+    QCOMPARE(moved.name(), "elem");
+}
+
+void XmlElementTest::assignment()
+{
+    XmlElement e("ns1");
+    e.setName("elem");
+    XmlElement copy;
+    copy = e;
+    QCOMPARE(copy.name(), "elem");
+    XmlElement moved;
+    moved = std::move(e);
+    QCOMPARE(moved.name(), "elem");
+}
+
+QTEST_MAIN(XmlElementTest)
+#include "tst_xmlelement.moc"

--- a/schema/CMakeLists.txt
+++ b/schema/CMakeLists.txt
@@ -33,10 +33,11 @@ add_library(xmlschema STATIC
 	${SCHEMA_SOURCES} ${SCHEMA_HEADERS}
 )
 
-target_link_libraries(xmlschema
+target_link_libraries(xmlschema PUBLIC
 	Qt5::Xml
+        xmlcommon
 )
 
 target_include_directories(xmlschema PUBLIC
-	Qt5::Xml
+   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>"
 )

--- a/schema/xmlelement.cpp
+++ b/schema/xmlelement.cpp
@@ -50,6 +50,11 @@ XmlElement::XmlElement(const XmlElement &other) : d(new Private)
     *d = *other.d;
 }
 
+XmlElement::XmlElement(XmlElement &&other) : d(new Private)
+{
+    *d = std::move(*other.d);
+}
+
 XmlElement::~XmlElement()
 {
     delete d;
@@ -57,13 +62,24 @@ XmlElement::~XmlElement()
 
 XmlElement &XmlElement::operator=(const XmlElement &other)
 {
-    if (this == &other) {
-        return *this;
-    }
-
-    *d = *other.d;
-
+    // copy+swap idiom, exception safe
+    XmlElement copy(other);
+    swap(copy);
     return *this;
+}
+
+XmlElement &XmlElement::operator=(XmlElement &&other) noexcept
+{
+    // move+swap idiom, exception safe
+    XmlElement moved(std::move(other));
+    swap(moved);
+    return *this;
+}
+
+void XmlElement::swap(XmlElement &other) noexcept
+{
+    using std::swap;
+    swap(*d, *other.d);
 }
 
 bool XmlElement::isNull() const

--- a/schema/xmlelement.h
+++ b/schema/xmlelement.h
@@ -35,11 +35,14 @@ class SCHEMA_EXPORT XmlElement
 {
 public:
     XmlElement();
-    XmlElement(const QString &nameSpace);
+    explicit XmlElement(const QString &nameSpace);
     XmlElement(const XmlElement &other);
+    XmlElement(XmlElement &&other);
     ~XmlElement();
 
     XmlElement &operator=(const XmlElement &other);
+    XmlElement &operator=(XmlElement &&other) noexcept;
+    void swap(XmlElement &other) noexcept;
 
     bool isNull() const;
 


### PR DESCRIPTION
With unittest.

If we agree on the way to do it, it can then be done just the same
in all other classes.

Initially prompted by a Coverity report suggesting that move operations
are missing.