### PR TITLE
Port all schema (XSD::) classes to unique_ptr and add move operations

### DIFF
--- a/autotests/CMakeLists.txt
+++ b/autotests/CMakeLists.txt
@@ -1,3 +1,9 @@
-add_executable(tst_xmlelement tst_xmlelement.cpp)
-target_link_libraries(tst_xmlelement xmlschema Qt${QT_MAJOR_VERSION}::Test)
-add_test(tst_xmlelement tst_xmlelement)
+macro(xmlschema_add_test _target)
+   add_executable(${_target} ${_global_add_executable_param} ${ARGN})
+   target_link_libraries(${_target} xmlschema Qt${QT_MAJOR_VERSION}::Test)
+   add_test(${_target} ${_target})
+endmacro()
+
+xmlschema_add_test(tst_xmlelement tst_xmlelement.cpp)
+xmlschema_add_test(tst_element tst_element.cpp)
+xmlschema_add_test(tst_group tst_group.cpp)

--- a/autotests/tst_element.cpp
+++ b/autotests/tst_element.cpp
@@ -1,0 +1,44 @@
+#include "element.h"
+
+#include <QTest>
+
+using namespace XSD;
+
+class ElementTest : public QObject
+{
+    Q_OBJECT
+private Q_SLOTS:
+    void constructors();
+    void assignment();
+};
+
+void ElementTest::constructors()
+{
+    Element e("ns1");
+    e.setName("elem");
+    e.setMinOccurs(3);
+    Element copy(e);
+    QCOMPARE(copy.name(), "elem");
+    QCOMPARE(copy.minOccurs(), 3);
+    Element moved = std::move(e);
+    QCOMPARE(moved.name(), "elem");
+    QCOMPARE(moved.minOccurs(), 3);
+}
+
+void ElementTest::assignment()
+{
+    Element e("ns1");
+    e.setName("elem");
+    e.setNillable(true);
+    Element copy;
+    copy = e;
+    QCOMPARE(copy.name(), "elem");
+    QVERIFY(copy.nillable());
+    Element moved;
+    moved = std::move(e);
+    QCOMPARE(moved.name(), "elem");
+    QVERIFY(moved.nillable());
+}
+
+QTEST_MAIN(ElementTest)
+#include "tst_element.moc"

--- a/autotests/tst_group.cpp
+++ b/autotests/tst_group.cpp
@@ -1,0 +1,48 @@
+#include "group.h"
+
+#include <QTest>
+
+using namespace XSD;
+
+class GroupTest : public QObject
+{
+    Q_OBJECT
+private Q_SLOTS:
+    void constructors();
+    void assignment();
+};
+
+void GroupTest::constructors()
+{
+    Group group;
+    group.setName("group");
+    group.setReference(QName("ns", "local"));
+    Group copy(group);
+    QCOMPARE(copy.name(), "group");
+    QCOMPARE(copy.reference().nameSpace(), "ns");
+    QCOMPARE(copy.reference().localName(), "local");
+    Group moved = std::move(group);
+    QCOMPARE(moved.name(), "group");
+    QCOMPARE(moved.reference().nameSpace(), "ns");
+    QCOMPARE(moved.reference().localName(), "local");
+}
+
+void GroupTest::assignment()
+{
+    Group group;
+    group.setName("group");
+    group.setReference(QName("ns", "local"));
+    Group copy;
+    copy = group;
+    QCOMPARE(copy.name(), "group");
+    QCOMPARE(copy.reference().nameSpace(), "ns");
+    QCOMPARE(copy.reference().localName(), "local");
+    Group moved;
+    moved = std::move(group);
+    QCOMPARE(moved.name(), "group");
+    QCOMPARE(moved.reference().nameSpace(), "ns");
+    QCOMPARE(moved.reference().localName(), "local");
+}
+
+QTEST_MAIN(GroupTest)
+#include "tst_group.moc"

--- a/schema/annotation.cpp
+++ b/schema/annotation.cpp
@@ -43,10 +43,9 @@ Annotation::Annotation(const Annotation &other) : d(new Private)
     *d = *other.d;
 }
 
-Annotation::~Annotation()
-{
-    delete d;
-}
+Annotation::Annotation(Annotation &&other) : d(std::move(other.d)) {}
+
+Annotation::~Annotation() = default;
 
 Annotation &Annotation::operator=(const Annotation &other)
 {
@@ -58,6 +57,9 @@ Annotation &Annotation::operator=(const Annotation &other)
 
     return *this;
 }
+
+Annotation &Annotation::operator=(Annotation &&other) noexcept = default;
+
 void Annotation::setDomElement(const QDomElement &element)
 {
     d->mDomElement = element;

--- a/schema/annotation.h
+++ b/schema/annotation.h
@@ -25,6 +25,7 @@
 #include <QDomElement>
 #include <QList>
 #include <kode_export.h>
+#include <memory>
 
 namespace XSD {
 
@@ -38,11 +39,14 @@ public:
     };
 
     Annotation();
-    Annotation(const QDomElement &element);
+    explicit Annotation(const QDomElement &element);
     Annotation(const Annotation &other);
+    Annotation(Annotation &&other);
+
     ~Annotation();
 
     Annotation &operator=(const Annotation &other);
+    Annotation &operator=(Annotation &&other) noexcept;
 
     void setDomElement(const QDomElement &element);
     QDomElement domElement() const;
@@ -54,7 +58,7 @@ public:
 
 private:
     class Private;
-    Private *d;
+    std::unique_ptr<Private> d;
 };
 }
 

--- a/schema/attribute.cpp
+++ b/schema/attribute.cpp
@@ -55,10 +55,9 @@ Attribute::Attribute(const Attribute &other) : XmlElement(other), d(new Private)
     *d = *other.d;
 }
 
-Attribute::~Attribute()
-{
-    delete d;
-}
+Attribute::Attribute(Attribute &&other) : XmlElement(other), d(std::move(other.d)) {}
+
+Attribute::~Attribute() = default;
 
 Attribute &Attribute::operator=(const Attribute &other)
 {
@@ -71,6 +70,8 @@ Attribute &Attribute::operator=(const Attribute &other)
 
     return *this;
 }
+
+Attribute &Attribute::operator=(Attribute &&other) noexcept = default;
 
 void Attribute::setType(const QName &type)
 {

--- a/schema/attribute.h
+++ b/schema/attribute.h
@@ -42,11 +42,13 @@ public:
     };
 
     Attribute();
-    Attribute(const QString &nameSpace);
+    explicit Attribute(const QString &nameSpace);
     Attribute(const Attribute &other);
+    Attribute(Attribute &&other);
     ~Attribute();
 
     Attribute &operator=(const Attribute &other);
+    Attribute &operator=(Attribute &&other) noexcept;
 
     void setType(const QName &type);
     QName type() const;
@@ -80,7 +82,7 @@ public:
 
 private:
     class Private;
-    Private *d;
+    std::unique_ptr<Private> d;
 };
 
 }

--- a/schema/attributegroup.cpp
+++ b/schema/attributegroup.cpp
@@ -42,10 +42,9 @@ AttributeGroup::AttributeGroup(const AttributeGroup &other) : XmlElement(other),
     *d = *other.d;
 }
 
-AttributeGroup::~AttributeGroup()
-{
-    delete d;
-}
+AttributeGroup::AttributeGroup(AttributeGroup &&other) : XmlElement(other), d(std::move(other.d)) {}
+
+AttributeGroup::~AttributeGroup() = default;
 
 AttributeGroup &AttributeGroup::operator=(const AttributeGroup &other)
 {
@@ -54,9 +53,12 @@ AttributeGroup &AttributeGroup::operator=(const AttributeGroup &other)
     }
 
     *d = *other.d;
+    XmlElement::operator=(other);
 
     return *this;
 }
+
+AttributeGroup &AttributeGroup::operator=(AttributeGroup &&other) noexcept = default;
 
 void AttributeGroup::setReference(const QName &reference)
 {

--- a/schema/attributegroup.h
+++ b/schema/attributegroup.h
@@ -35,9 +35,11 @@ public:
 
     AttributeGroup();
     AttributeGroup(const AttributeGroup &other);
+    AttributeGroup(AttributeGroup &&other);
     ~AttributeGroup();
 
     AttributeGroup &operator=(const AttributeGroup &other);
+    AttributeGroup &operator=(AttributeGroup &&other) noexcept;
 
     void setReference(const QName &reference);
     QName reference() const;
@@ -50,7 +52,7 @@ public:
 
 private:
     class Private;
-    Private *d;
+    std::unique_ptr<Private> d;
 };
 
 }

--- a/schema/complextype.cpp
+++ b/schema/complextype.cpp
@@ -64,10 +64,9 @@ ComplexType::ComplexType(const ComplexType &other) : XSDType(other), d(new Priva
     *d = *other.d;
 }
 
-ComplexType::~ComplexType()
-{
-    delete d;
-}
+ComplexType::ComplexType(ComplexType &&other) : XSDType(other), d(std::move(other.d)) {}
+
+ComplexType::~ComplexType() = default;
 
 ComplexType &ComplexType::operator=(const ComplexType &other)
 {
@@ -80,6 +79,8 @@ ComplexType &ComplexType::operator=(const ComplexType &other)
 
     return *this;
 }
+
+ComplexType &ComplexType::operator=(ComplexType &&other) noexcept = default;
 
 void ComplexType::setDocumentation(const QString &documentation)
 {

--- a/schema/complextype.h
+++ b/schema/complextype.h
@@ -45,11 +45,13 @@ public:
     typedef enum { Restriction, Extension } Derivation;
 
     ComplexType();
-    ComplexType(const QString &nameSpace);
+    explicit ComplexType(const QString &nameSpace);
     ComplexType(const ComplexType &other);
+    ComplexType(ComplexType &&other);
     ~ComplexType();
 
     ComplexType &operator=(const ComplexType &other);
+    ComplexType &operator=(ComplexType &&other) noexcept;
 
     void setDocumentation(const QString &documentation);
     QString documentation() const;
@@ -103,7 +105,7 @@ public:
 
 private:
     class Private;
-    Private *d;
+    std::unique_ptr<Private> d;
 };
 
 class SCHEMA_EXPORT ComplexTypeList : public QList<ComplexType>

--- a/schema/compositor.cpp
+++ b/schema/compositor.cpp
@@ -48,10 +48,9 @@ Compositor::Compositor(const Compositor &other) : d(new Private)
     *d = *other.d;
 }
 
-Compositor::~Compositor()
-{
-    delete d;
-}
+Compositor::Compositor(Compositor &&other) : d(std::move(other.d)) {}
+
+Compositor::~Compositor() = default;
 
 Compositor &Compositor::operator=(const Compositor &other)
 {
@@ -63,6 +62,8 @@ Compositor &Compositor::operator=(const Compositor &other)
 
     return *this;
 }
+
+Compositor &Compositor::operator=(Compositor &&other) noexcept = default;
 
 bool Compositor::isValid() const
 {

--- a/schema/compositor.h
+++ b/schema/compositor.h
@@ -26,6 +26,7 @@
 #include <QString>
 #include <common/qname.h>
 #include <kode_export.h>
+#include <memory>
 
 namespace XSD {
 
@@ -39,11 +40,14 @@ public:
     Q_ENUM(Type)
 
     Compositor();
-    Compositor(Type type);
+    explicit Compositor(Type type);
     Compositor(const Compositor &other);
+    Compositor(Compositor &&other);
+
     ~Compositor();
 
     Compositor &operator=(const Compositor &other);
+    Compositor &operator=(Compositor &&other) noexcept;
 
     bool isValid() const;
 
@@ -62,7 +66,7 @@ public:
 
 private:
     class Private;
-    Private *d;
+    std::unique_ptr<Private> d;
 };
 }
 

--- a/schema/element.cpp
+++ b/schema/element.cpp
@@ -74,10 +74,9 @@ Element::Element(const Element &other) : XmlElement(other), d(new Private)
     *d = *other.d;
 }
 
-Element::~Element()
-{
-    delete d;
-}
+Element::Element(Element &&other) : XmlElement(other), d(std::move(other.d)) {}
+
+Element::~Element() = default;
 
 Element &Element::operator=(const Element &other)
 {
@@ -90,6 +89,8 @@ Element &Element::operator=(const Element &other)
 
     return *this;
 }
+
+Element &Element::operator=(Element &&other) noexcept = default;
 
 void Element::setType(const QName &type)
 {

--- a/schema/element.h
+++ b/schema/element.h
@@ -40,11 +40,13 @@ public:
     typedef ElementList List;
 
     Element();
-    Element(const QString &nameSpace);
+    explicit Element(const QString &nameSpace);
     Element(const Element &other);
+    Element(Element &&other);
     ~Element();
 
     Element &operator=(const Element &other);
+    Element &operator=(Element &&other) noexcept;
 
     void setType(const QName &type);
     QName type() const;
@@ -103,7 +105,7 @@ public:
 
 private:
     class Private;
-    Private *d;
+    std::unique_ptr<Private> d;
 };
 
 class SCHEMA_EXPORT ElementList : public QList<Element>

--- a/schema/group.cpp
+++ b/schema/group.cpp
@@ -42,10 +42,9 @@ Group::Group(const Group &other) : XmlElement(other), d(new Private)
     *d = *other.d;
 }
 
-Group::~Group()
-{
-    delete d;
-}
+Group::Group(Group &&other) : XmlElement(other), d(std::move(other.d)) {}
+
+Group::~Group() = default;
 
 Group &Group::operator=(const Group &other)
 {
@@ -54,9 +53,12 @@ Group &Group::operator=(const Group &other)
     }
 
     *d = *other.d;
+    XmlElement::operator=(other);
 
     return *this;
 }
+
+Group &Group::operator=(Group &&other) noexcept = default;
 
 void Group::setReference(const QName &reference)
 {

--- a/schema/group.h
+++ b/schema/group.h
@@ -17,9 +17,12 @@ public:
 
     Group();
     Group(const Group &other);
-    ~Group();
+    Group(Group &&other);
+
+    ~Group() override;
 
     Group &operator=(const Group &other);
+    Group &operator=(Group &&other) noexcept;
 
     void setReference(const QName &reference);
     QName reference() const;
@@ -34,7 +37,7 @@ public:
 
 private:
     class Private;
-    Private *d;
+    std::unique_ptr<Private> d;
 };
 
 }

--- a/schema/parser.cpp
+++ b/schema/parser.cpp
@@ -92,10 +92,11 @@ Parser::Parser(const Parser &other) : d(new Private)
     *d = *other.d;
 }
 
+Parser::Parser(Parser &&other) : d(std::move(other.d)) {}
+
 Parser::~Parser()
 {
-    clear();
-    delete d;
+    clear(); // why?
 }
 
 Parser &Parser::operator=(const Parser &other)
@@ -108,6 +109,8 @@ Parser &Parser::operator=(const Parser &other)
 
     return *this;
 }
+
+Parser &Parser::operator=(Parser &&other) noexcept = default;
 
 void Parser::setLocalSchemas(const QMap<QUrl, QString> &localSchemas)
 {

--- a/schema/parser.h
+++ b/schema/parser.h
@@ -48,13 +48,17 @@ class SCHEMA_EXPORT Parser
 public:
     enum { UNBOUNDED = 100000 };
 
-    Parser(ParserContext *context, const QString &nameSpace = QString(),
-           bool useLocalFilesOnly = false, const QStringList &includePathList = QStringList());
-    Parser(const QString &nameSpace = QString());
+    explicit Parser(ParserContext *context, const QString &nameSpace = QString(),
+                    bool useLocalFilesOnly = false,
+                    const QStringList &includePathList = QStringList());
+    explicit Parser(const QString &nameSpace = QString());
     Parser(const Parser &other);
+    Parser(Parser &&other);
+
     ~Parser();
 
     Parser &operator=(const Parser &other);
+    Parser &operator=(Parser &&other) noexcept;
 
     /**
      * Configures the parser to use some local files instead of downloading specific schemas.
@@ -143,7 +147,7 @@ private:
     void clear();
 
     class Private;
-    Private *d;
+    std::unique_ptr<Private> d;
 };
 }
 

--- a/schema/simpletype.cpp
+++ b/schema/simpletype.cpp
@@ -72,10 +72,9 @@ SimpleType::SimpleType(const SimpleType &other) : XSDType(other), d(new Private)
     *d = *other.d;
 }
 
-SimpleType::~SimpleType()
-{
-    delete d;
-}
+SimpleType::SimpleType(SimpleType &&other) : XSDType(other), d(std::move(other.d)) {}
+
+SimpleType::~SimpleType() = default;
 
 SimpleType &SimpleType::operator=(const SimpleType &other)
 {
@@ -84,9 +83,12 @@ SimpleType &SimpleType::operator=(const SimpleType &other)
     }
 
     *d = *other.d;
+    XSDType::operator=(other);
 
     return *this;
 }
+
+SimpleType &SimpleType::operator=(SimpleType &&other) noexcept = default;
 
 void SimpleType::setDocumentation(const QString &documentation)
 {

--- a/schema/simpletype.h
+++ b/schema/simpletype.h
@@ -59,11 +59,14 @@ public:
     enum SubType { TypeRestriction, TypeList, TypeUnion };
 
     SimpleType();
-    SimpleType(const QString &nameSpace);
+    explicit SimpleType(const QString &nameSpace);
     SimpleType(const SimpleType &other);
+    SimpleType(SimpleType &&other);
+
     ~SimpleType();
 
     SimpleType &operator=(const SimpleType &other);
+    SimpleType &operator=(SimpleType &&other) noexcept;
 
     void setDocumentation(const QString &documentation);
     QString documentation() const;
@@ -109,7 +112,7 @@ public:
 
 private:
     class Private;
-    Private *d;
+    std::unique_ptr<Private> d;
 };
 
 class SCHEMA_EXPORT SimpleTypeList : public QList<SimpleType>

--- a/schema/types.cpp
+++ b/schema/types.cpp
@@ -45,10 +45,9 @@ Types::Types(const Types &other) : d(new Private)
     *d = *other.d;
 }
 
-Types::~Types()
-{
-    delete d;
-}
+Types::Types(Types &&other) : d(std::move(other.d)) {}
+
+Types::~Types() = default;
 
 Types &Types::operator=(const Types &other)
 {
@@ -60,6 +59,8 @@ Types &Types::operator=(const Types &other)
 
     return *this;
 }
+
+Types &Types::operator=(Types &&other) noexcept = default;
 
 Types &Types::operator+=(const Types &other)
 {

--- a/schema/types.h
+++ b/schema/types.h
@@ -34,9 +34,11 @@ class SCHEMA_EXPORT Types
 public:
     Types();
     Types(const Types &other);
+    Types(Types &&other);
     ~Types();
 
     Types &operator=(const Types &other);
+    Types &operator=(Types &&other) noexcept;
     Types &operator+=(const Types &other);
 
     void setSimpleTypes(const SimpleType::List &simpleTypes);
@@ -69,7 +71,7 @@ public:
 
 private:
     class Private;
-    Private *d;
+    std::unique_ptr<Private> d;
 };
 }
 

--- a/schema/xmlelement.cpp
+++ b/schema/xmlelement.cpp
@@ -50,37 +50,20 @@ XmlElement::XmlElement(const XmlElement &other) : d(new Private)
     *d = *other.d;
 }
 
-XmlElement::XmlElement(XmlElement &&other) : d(new Private)
-{
-    *d = std::move(*other.d);
-}
+XmlElement::XmlElement(XmlElement &&other) : d(std::move(other.d)) {}
 
-XmlElement::~XmlElement()
-{
-    delete d;
-}
+XmlElement::~XmlElement() = default;
 
 XmlElement &XmlElement::operator=(const XmlElement &other)
 {
-    // copy+swap idiom, exception safe
-    XmlElement copy(other);
-    swap(copy);
+    if (this == &other) {
+        return *this;
+    }
+    *d = *other.d;
     return *this;
 }
 
-XmlElement &XmlElement::operator=(XmlElement &&other) noexcept
-{
-    // move+swap idiom, exception safe
-    XmlElement moved(std::move(other));
-    swap(moved);
-    return *this;
-}
-
-void XmlElement::swap(XmlElement &other) noexcept
-{
-    using std::swap;
-    swap(*d, *other.d);
-}
+XmlElement &XmlElement::operator=(XmlElement &&other) noexcept = default;
 
 bool XmlElement::isNull() const
 {

--- a/schema/xmlelement.h
+++ b/schema/xmlelement.h
@@ -27,6 +27,7 @@
 #include <common/qname.h>
 #include <kode_export.h>
 
+#include <memory>
 #include <QString>
 
 namespace XSD {
@@ -38,11 +39,10 @@ public:
     explicit XmlElement(const QString &nameSpace);
     XmlElement(const XmlElement &other);
     XmlElement(XmlElement &&other);
-    ~XmlElement();
+    virtual ~XmlElement();
 
     XmlElement &operator=(const XmlElement &other);
     XmlElement &operator=(XmlElement &&other) noexcept;
-    void swap(XmlElement &other) noexcept;
 
     bool isNull() const;
 
@@ -63,7 +63,7 @@ public:
 
 private:
     class Private;
-    Private *d;
+    std::unique_ptr<Private> d;
 };
 
 }

--- a/schema/xsdtype.cpp
+++ b/schema/xsdtype.cpp
@@ -42,10 +42,9 @@ XSDType::XSDType(const XSDType &other) : XmlElement(other), d(new Private)
     *d = *other.d;
 }
 
-XSDType::~XSDType()
-{
-    delete d;
-}
+XSDType::XSDType(XSDType &&other) : XmlElement(other), d(std::move(other.d)) {}
+
+XSDType::~XSDType() = default;
 
 XSDType &XSDType::operator=(const XSDType &other)
 {
@@ -58,6 +57,8 @@ XSDType &XSDType::operator=(const XSDType &other)
 
     return *this;
 }
+
+XSDType &XSDType::operator=(XSDType &&other) noexcept = default;
 
 void XSDType::setContentModel(ContentModel contentModel)
 {

--- a/schema/xsdtype.h
+++ b/schema/xsdtype.h
@@ -75,10 +75,13 @@ public:
         };
     */
     XSDType();
-    XSDType(const QString &);
+    explicit XSDType(const QString &);
     XSDType(const XSDType &other);
-    virtual ~XSDType();
+    XSDType(XSDType &&other);
 
+    ~XSDType() override;
+
+    XSDType &operator=(XSDType &&other) noexcept;
     XSDType &operator=(const XSDType &other);
 
     void setContentModel(ContentModel contentModel);
@@ -106,7 +109,7 @@ public:
 
 private:
     class Private;
-    Private *d;
+    std::unique_ptr<Private> d;
 };
 }
 


### PR DESCRIPTION
This partially reverts the previous commit in XmlElement to choose a
more optimal solution. The copy constructor is as before (instead of
calling a too-generic std::swap that will create more temporaries).
The move constructor was allocating needlessly, we just need to
grab the pointer of the other instance.
So instead this now uses unique_ptr to simplify the destructor and because
it gives us the move operations automatically.

Independently from move operations, this code review also spotted
a number of missing calls to base classes in the existing operator=.
Proved by unittests, and fixed.