### PR TITLE
Port away from deprecated QXmlInputSource

### DIFF
--- a/schema/parser.h
+++ b/schema/parser.h
@@ -67,7 +67,7 @@ public:
 
     Annotation::List annotations() const;
 
-    bool parseString(ParserContext *context, const QString &data);
+    bool parseString(ParserContext *context, const QByteArray &data);
     bool parseFile(ParserContext *context, QFile &file);
     bool parseSchemaTag(ParserContext *context, const QDomElement &element);
 
@@ -85,7 +85,7 @@ public:
     static QString schemaUri();
 
 private:
-    bool parse(ParserContext *context, QXmlInputSource *source);
+    bool parse(ParserContext *context, QIODevice *sourceDevice);
 
     void parseImport(ParserContext *context, const QDomElement &);
     /**


### PR DESCRIPTION
It's a bit surprising, but we want to pass false
for the namespaceProcessing argument of QDomDocument::setContent().
That's because we do our own namespace processing here, including
propagating namespace prefixes between imported schemas etc.

KDSoap's unittests still pass with this change.