### PR TITLE
Generate static members initializers into the declaration

### DIFF
--- a/code_generation/printer.cpp
+++ b/code_generation/printer.cpp
@@ -267,9 +267,10 @@ QString Printer::Private::classHeader(const Class &classObject, bool publicMembe
                 if (v.isStatic())
                     decl += "static ";
 
-                decl += formatType(v.type());
-
-                decl += v.name() + ';';
+                if (!v.isStatic() && v.initializer().isEmpty())
+                    decl += v.name() + ';';
+                else
+                    decl += v.name() + " = " + v.initializer() + ';';
 
                 code += decl;
             }
@@ -360,16 +361,6 @@ QString Printer::Private::classImplementation(const Class &classObject, bool nes
         if (classObject.useDPointer() && !classObject.memberVariables().isEmpty()
             && f.name() == classObject.name()) {
             inits.append(classObject.dPointerName() + "(new PrivateDPtr)");
-        }
-        if (!classObject.useDPointer() && f.name() == classObject.name()
-            && f.arguments().isEmpty()) {
-            // Default constructor: add initializers for variables
-            for (itV = vars.constBegin(); itV != vars.constEnd(); ++itV) {
-                const MemberVariable v = *itV;
-                if (!v.initializer().isEmpty()) {
-                    inits.append(v.name() + '(' + v.initializer() + ')');
-                }
-            }
         }
 
         if (!inits.isEmpty()) {


### PR DESCRIPTION
Hello David,

I quite like doing the member initialization in the declaration rather than in the constructor.
I created a change which allows me to do this in the libkode generated codes.

Before review I would like to hear your opinion on this one: can we go ahead and enforce this behavior generally or shall I create an optional configuration for it?
If the later I will work on it, if you have no objection please review my change. Thanks!
