### PR TITLE
Add support for generating function declarations with explicit specifier

### DIFF
--- a/code_generation/class.cpp
+++ b/code_generation/class.cpp
@@ -29,14 +29,12 @@ using namespace KODE;
 class Class::Private
 {
 public:
-    Private() : mDPointer(), mUseSharedData(false), mCanBeCopied(false) {}
-
     QString mName;
     QString mNameSpace;
     QString mExportDeclaration;
     QString mDPointer;
-    bool mUseSharedData;
-    bool mCanBeCopied;
+    bool mUseSharedData = false;
+    bool mCanBeCopied = false;
     Function::List mFunctions;
     MemberVariable::List mMemberVariables;
     QStringList mIncludes;

--- a/code_generation/function.cpp
+++ b/code_generation/function.cpp
@@ -78,20 +78,17 @@ Function::Argument::~Argument()
 class Function::FunctionPrivate
 {
 public:
-    FunctionPrivate() : mAccess(Public), mIsConst(false), mIsStatic(false), mVirtualMode(NotVirtual)
-    {
-    }
-
-    int mAccess;
-    bool mIsConst;
-    bool mIsStatic;
+    int mAccess = Public;
+    bool mIsConst = false;
+    bool mIsStatic = false;
+    bool mIsExplicit = false;
     QString mReturnType;
     QString mName;
     Argument::List mArguments;
     QStringList mInitializers;
     QString mBody;
     QString mDocs;
-    Function::VirtualMode mVirtualMode;
+    Function::VirtualMode mVirtualMode = NotVirtual;
 };
 
 Function::Function() : d(new FunctionPrivate) {}
@@ -261,6 +258,16 @@ void Function::setDocs(const QString &docs)
 QString Function::docs() const
 {
     return d->mDocs;
+}
+
+bool Function::isExplicit() const
+{
+    return d->mIsExplicit;
+}
+
+void Function::setExplicit(bool isExplicit)
+{
+    d->mIsExplicit = isExplicit;
 }
 
 bool Function::hasArguments() const

--- a/code_generation/function.h
+++ b/code_generation/function.h
@@ -230,6 +230,16 @@ public:
      */
     QString docs() const;
 
+    /**
+     * Sets whether the function is marked with explicit specifier.
+     */
+    void setExplicit(bool isExplicit = true);
+
+    /**
+     * Returns whether the function is marked with explicit specifier.
+     */
+    bool isExplicit() const;
+
 private:
     class FunctionPrivate;
     FunctionPrivate *d;

--- a/code_generation/printer.cpp
+++ b/code_generation/printer.cpp
@@ -573,11 +573,15 @@ QString Printer::functionSignature(const Function &function, const QString &clas
     QString s;
 
     if (function.isStatic() && !forImplementation) {
-        s += "static ";
+        s += QStringLiteral("static ");
     }
 
     if (function.virtualMode() != Function::NotVirtual && !forImplementation) {
-        s += "virtual ";
+        s += QStringLiteral("virtual ");
+    }
+
+    if (function.isExplicit() && !forImplementation) {
+        s += QStringLiteral("explicit ");
     }
 
     QString ret = function.returnType();


### PR DESCRIPTION
Hi @dfaure-kdab 

As we discussed here:
https://github.com/KDAB/KDSoap/issues/206
I added a method for generating classes with explicit specifier.

I know it is not nice, but I included some "code cleanup" while I was poking around the code. Could you please review them as well?

I was wondering about setting a default true value for the isExplicit argument of the setExplicit method. What do you think about this one?