### PR TITLE
Fix Qt 6.3 regression, QString null vs empty mixup.

### DIFF
--- a/code_generation/printer.cpp
+++ b/code_generation/printer.cpp
@@ -770,7 +770,7 @@ void Printer::printHeader(const File &file)
             out.indent();
         }
 
-        if (!clas.isNull()) {
+        if (!clas.isEmpty()) {
             const bool isQtClass =
                     clas.startsWith(QLatin1Char('Q')) && !clas.contains(QLatin1Char('_'));
             if (isQtClass)


### PR DESCRIPTION
This was generating "class ;" without any class name, in KDSoap.

It's more correct to use isEmpty() rather than rely on isNull()
behaviour from QString::split() anyway.